### PR TITLE
fix: oracledb certs directory path

### DIFF
--- a/testconfig/p2p-oracle/oracledb.dockerfile
+++ b/testconfig/p2p-oracle/oracledb.dockerfile
@@ -1,8 +1,8 @@
 FROM postgres:16.2
 
 RUN mkdir certs
-COPY ./testconfig/oracle/certs/db/db.crt /certs/
-COPY ./testconfig/oracle/certs/db/db.key /certs/
+COPY ./testconfig/p2p-oracle/certs/db/db.crt /certs/
+COPY ./testconfig/p2p-oracle/certs/db/db.key /certs/
 RUN chmod 600 /certs/db.key
 RUN chown postgres /certs/db.key
 


### PR DESCRIPTION
With the new test config these are under /p2p-oracle/ 