### PR TITLE
fix: max witness length default 108

### DIFF
--- a/ddk-manager/src/conversion_utils.rs
+++ b/ddk-manager/src/conversion_utils.rs
@@ -79,7 +79,7 @@ pub fn get_tx_input_infos(
         let max_witness_len = if fund_input.dlc_input.is_some() {
             220
         } else {
-            107
+            108
         };
         let tx = Transaction::consensus_decode(&mut fund_input.prev_tx.as_slice())?;
         let vout = fund_input.prev_tx_vout;

--- a/ddk-manager/src/utils.rs
+++ b/ddk-manager/src/utils.rs
@@ -136,7 +136,7 @@ where
         let prev_tx_vout = utxo.outpoint.vout;
         let sequence = 0xffffffff;
         // TODO(tibo): this assumes P2WPKH with low R
-        let max_witness_len = 107;
+        let max_witness_len = 108;
         let funding_input = FundingInput {
             input_serial_id: get_new_serial_id(),
             prev_tx: writer,

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -73,7 +73,7 @@ const TX_INPUT_BASE_WEIGHT: usize = 164;
 
 /// The witness size of a P2WPKH input
 /// See: <https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#fees>
-pub const P2WPKH_WITNESS_SIZE: usize = 107;
+pub const P2WPKH_WITNESS_SIZE: usize = 108;
 
 macro_rules! checked_add {
     ($a: expr, $b: expr) => {


### PR DESCRIPTION
## What

Default max witness length to 108

## Why

TS libraries default to 108