### PR TITLE
fix: improve splice logic & prevent DLC input duplication

### DIFF
--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -157,7 +157,8 @@ where
     );
 
     // Check BOTH parties for DLC inputs - either party having DLC inputs means we need splicing
-    let has_dlc_inputs = !accept_params.dlc_inputs.is_empty() || !offered_contract.offer_params.dlc_inputs.is_empty();
+    let has_dlc_inputs = !accept_params.dlc_inputs.is_empty()
+        || !offered_contract.offer_params.dlc_inputs.is_empty();
 
     let dlc_transactions = if has_dlc_inputs {
         log_debug!(
@@ -176,10 +177,7 @@ where
             offered_contract.fund_output_serial_id,
         )?
     } else {
-        log_debug!(
-            logger,
-            "Creating DLC transactions without splicing."
-        );
+        log_debug!(logger, "Creating DLC transactions without splicing.");
         ddk_dlc::create_dlc_transactions(
             &offered_contract.offer_params,
             &accept_params,
@@ -389,7 +387,8 @@ where
     let total_collateral = offered_contract.total_collateral;
 
     // Check BOTH parties for DLC inputs - either party having DLC inputs means we need splicing
-    let has_dlc_inputs = !accept_dlc_inputs.is_empty() || !offered_contract.offer_params.dlc_inputs.is_empty();
+    let has_dlc_inputs =
+        !accept_dlc_inputs.is_empty() || !offered_contract.offer_params.dlc_inputs.is_empty();
 
     let dlc_transactions = if has_dlc_inputs {
         log_debug!(
@@ -408,10 +407,7 @@ where
             offered_contract.fund_output_serial_id,
         )?
     } else {
-        log_debug!(
-            logger,
-            "Creating DLC transactions without splicing."
-        );
+        log_debug!(logger, "Creating DLC transactions without splicing.");
         ddk_dlc::create_dlc_transactions(
             &offered_contract.offer_params,
             &accept_params,

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -444,8 +444,12 @@ pub fn create_spliced_dlc_transactions(
     // Filter out DLC inputs from regular inputs to avoid duplicates
     // DLC inputs are already included in the inputs[] array, so we need to remove them
     // before adding them back from dlc_inputs[] to avoid double-counting
-    enhanced_offer_params.inputs.retain(|input| input.max_witness_len <= 108);
-    enhanced_accept_params.inputs.retain(|input| input.max_witness_len <= 108);
+    enhanced_offer_params
+        .inputs
+        .retain(|input| input.max_witness_len <= 108);
+    enhanced_accept_params
+        .inputs
+        .retain(|input| input.max_witness_len <= 108);
 
     let offer_dlc_tx_inputs = offer_params
         .dlc_inputs

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -441,6 +441,12 @@ pub fn create_spliced_dlc_transactions(
     let mut enhanced_offer_params = offer_params.clone();
     let mut enhanced_accept_params = accept_params.clone();
 
+    // Filter out DLC inputs from regular inputs to avoid duplicates
+    // DLC inputs are already included in the inputs[] array, so we need to remove them
+    // before adding them back from dlc_inputs[] to avoid double-counting
+    enhanced_offer_params.inputs.retain(|input| input.max_witness_len <= 108);
+    enhanced_accept_params.inputs.retain(|input| input.max_witness_len <= 108);
+
     let offer_dlc_tx_inputs = offer_params
         .dlc_inputs
         .iter()


### PR DESCRIPTION
## Problem
The existing splice logic had two main issues:

1. **Incomplete DLC input detection**: Only checked the accept party for DLC inputs, missing cases where the offer party had DLC inputs
2. **DLC input duplication**: DLC inputs were being double-counted as both regular inputs and DLC inputs

## Solution
This PR addresses both issues:

### 1. DLC Input Detection
- Now checks **both** offer and accept parties for DLC inputs
- Uses `has_dlc_inputs` boolean to determine whether to use spliced or regular DLC transactions
- Consistent logic applied in both `create_signed_contract_from_offer` and `accept_contract_offer`

### 2. DLC Input Deduplication
- Added filtering logic in `create_spliced_dlc_transactions()` to remove DLC inputs from regular inputs
- Uses `max_witness_len <= 108` as the filter criteria to identify and retain only non-DLC inputs
- Prevents double-counting that could cause transaction creation issues

### 3. Improved Logging
- Added debug logs to clearly indicate when splice vs non-splice transactions are being created
- Logs the total count of DLC inputs from both parties

## Testing
- [x] Existing splice tests continue to pass
- [x] New scenarios with offer-party DLC inputs work correctly
- [x] No new issues with non-splice DLC creation

## Files Changed
- `ddk-manager/src/contract_updater.rs`: Updated splice detection logic
- `dlc/src/lib.rs`: Added DLC input deduplication in splice transaction creation