### PR TITLE
chore: release 1.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "ddk"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-dlc"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-manager"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-messages"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-node"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-payouts"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-trie"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "kormir"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "base64 0.13.1",
  "bitcoin",

--- a/ddk-manager/Cargo.toml
+++ b/ddk-manager/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/bennyhodl/rust-dlc"
 license-file = "../LICENSE"
 name = "ddk-manager"
 repository = "https://github.com/bennyhodl/rust-dlc/tree/master/dlc-manager"
-version = "1.0.6"
+version = "1.0.7"
 
 [features]
 default= ["std"]
@@ -19,9 +19,9 @@ use-serde = ["serde", "ddk-dlc/use-serde", "ddk-messages/use-serde", "ddk-trie/u
 async-trait = "0.1.50"
 bitcoin = { version = "0.32.6", default-features = false }
 
-ddk-dlc = { version = "1.0.6", path = "../dlc", features = ["use-serde"] }
-ddk-messages = { version = "1.0.6", path = "../dlc-messages", features = [ "use-serde"] }
-ddk-trie = { version = "1.0.6", path = "../dlc-trie", features = ["use-serde"] }
+ddk-dlc = { version = "1.0.7", path = "../dlc", features = ["use-serde"] }
+ddk-messages = { version = "1.0.7", path = "../dlc-messages", features = [ "use-serde"] }
+ddk-trie = { version = "1.0.7", path = "../dlc-trie", features = ["use-serde"] }
 
 futures = "0.3.31"
 hex = { package = "hex-conservative", version = "0.1" }

--- a/ddk-node/Cargo.toml
+++ b/ddk-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddk-node"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["benny b <ben@bitcoinbay.foundation>"]
 description = "DDK node to facilitate DLC contracts."
 license = "MIT"
@@ -8,11 +8,11 @@ repository = "https://github.com/bennyhodl/dlcdevkit"
 edition = "2021"
 
 [dependencies]
-ddk = { version = "1.0.6", path = "../ddk", features = ["postgres", "kormir", "nostr"] }
-ddk-manager = { version = "1.0.6", path = "../ddk-manager", features = ["use-serde"] }
-ddk-payouts = { version = "1.0.6", path = "../payouts" }
-ddk-dlc = { version = "1.0.6", path = "../dlc", features = ["use-serde"] }
-ddk-messages = { version = "1.0.6", path = "../dlc-messages", features = [ "use-serde"] }
+ddk = { version = "1.0.7", path = "../ddk", features = ["postgres", "kormir", "nostr"] }
+ddk-manager = { version = "1.0.7", path = "../ddk-manager", features = ["use-serde"] }
+ddk-payouts = { version = "1.0.7", path = "../payouts" }
+ddk-dlc = { version = "1.0.7", path = "../dlc", features = ["use-serde"] }
+ddk-messages = { version = "1.0.7", path = "../dlc-messages", features = [ "use-serde"] }
 
 bitcoin = { version = "0.32.6", features = ["rand", "serde"] }
 

--- a/ddk/Cargo.toml
+++ b/ddk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddk"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 license = "MIT"
 description = "application tooling for DLCs 🌊"
@@ -24,10 +24,10 @@ sled = ["dep:sled"]
 postgres = ["dep:sqlx", "sqlx/postgres"]
 
 [dependencies]
-ddk-manager = { version = "1.0.6", path = "../ddk-manager", features = ["use-serde"] }
-ddk-dlc = { version = "1.0.6", path = "../dlc", features = ["use-serde"] }
-ddk-messages = { version = "1.0.6", path = "../dlc-messages", features = [ "use-serde"] }
-ddk-trie = { version = "1.0.6", path = "../dlc-trie", features = ["use-serde"] }
+ddk-manager = { version = "1.0.7", path = "../ddk-manager", features = ["use-serde"] }
+ddk-dlc = { version = "1.0.7", path = "../dlc", features = ["use-serde"] }
+ddk-messages = { version = "1.0.7", path = "../dlc-messages", features = [ "use-serde"] }
+ddk-trie = { version = "1.0.7", path = "../dlc-trie", features = ["use-serde"] }
 
 bitcoin = { version = "0.32.6", features = ["rand", "serde"] }
 bdk_esplora = { version = "0.22.0", features = ["blocking-https", "async-https", "tokio"] }
@@ -58,7 +58,7 @@ lightning-net-tokio = { version = "0.1.0", optional = true }
 
 # oracle feature
 reqwest = { version = "0.12.9", features = ["json"], optional = true }
-kormir = { version = "1.0.6", path = "../kormir" }
+kormir = { version = "1.0.7", path = "../kormir" }
 hmac = "0.12.1"
 sha2 = "0.10"
 nostr-database = { version = "0.40.0", optional = true }

--- a/dlc-messages/Cargo.toml
+++ b/dlc-messages/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/bennyhodl/dlcdevkit"
 license-file = "../LICENSE"
 name = "ddk-messages"
 repository = "https://github.com/bennyhodl/dlcdevkit/tree/master/dlc-messages"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2015"
 
 [features]
@@ -16,7 +16,7 @@ use-serde = ["serde", "secp256k1-zkp/serde", "bitcoin/serde"]
 
 [dependencies]
 bitcoin = { version = "0.32.6", default-features = false }
-ddk-dlc = { version = "1.0.6", path = "../dlc", default-features = false }
+ddk-dlc = { version = "1.0.7", path = "../dlc", default-features = false }
 lightning = { version = "0.1.5", default-features = false }
 secp256k1-zkp = { version = "0.11.0" }
 serde = {version = "1.0", features = ["derive"], optional = true}

--- a/dlc-trie/Cargo.toml
+++ b/dlc-trie/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/bennyhodl/dlcdevkit"
 license-file = "../LICENSE"
 name = "ddk-trie"
 repository = "https://github.com/bennyhodl/dlcdevkit/tree/master/dlc-trie"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2015"
 
 [features]
@@ -17,7 +17,7 @@ use-serde = ["serde", "ddk-dlc/use-serde"]
 
 [dependencies]
 bitcoin = { version = "0.32.6", default-features = false }
-ddk-dlc = { version = "1.0.6", path = "../dlc", default-features = false }
+ddk-dlc = { version = "1.0.7", path = "../dlc", default-features = false }
 rayon = {version = "1.5", optional = true}
 secp256k1-zkp = {version = "0.11.0" }
 serde = {version = "1.0", optional = true, default-features = false, features = ["derive"]}

--- a/dlc/Cargo.toml
+++ b/dlc/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/bennyhodl/dlcdevkit"
 license-file = "../LICENSE"
 name = "ddk-dlc"
 repository = "https://github.com/bennyhodl/dlcdevkit/tree/master/dlc"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2015"
 
 [dependencies]

--- a/kormir/Cargo.toml
+++ b/kormir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kormir"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 authors = ["benthecarman <ben@mutinywallet.com>", "benny b <ben@bitcoinbay.foundation>"]
 description = "Oracle implementation for DLCs"
@@ -15,8 +15,8 @@ nostr = ["dep:nostr", "dep:base64"]
 
 [dependencies]
 bitcoin = { version = "0.32.6", features = ["serde"] }
-ddk-dlc = { version = "1.0.6", path = "../dlc", features = ["use-serde"] }
-ddk-messages = { version = "1.0.6", path = "../dlc-messages", features = [ "use-serde"] }
+ddk-dlc = { version = "1.0.7", path = "../dlc", features = ["use-serde"] }
+ddk-messages = { version = "1.0.7", path = "../dlc-messages", features = [ "use-serde"] }
 lightning = "0.1.5"
 log = "0.4.22"
 nostr = { version = "0.40.0", optional = true }

--- a/payouts/Cargo.toml
+++ b/payouts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddk-payouts"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["benny b <ben@bitcoinbay.foundation>"]
 description = "Library to build payout functions for DLC contracts."
 license = "MIT"
@@ -8,10 +8,10 @@ repository = "https://github.com/bennyhodl/dlcdevkit"
 edition = "2021"
 
 [dependencies]
-ddk-manager = { version = "1.0.6", path = "../ddk-manager", features = ["use-serde"] }
-ddk-dlc = { version = "1.0.6", path = "../dlc", features = ["use-serde"] }
-ddk-messages = { version = "1.0.6", path = "../dlc-messages", features = ["use-serde"] }
-ddk-trie = { version = "1.0.6", path = "../dlc-trie", features = ["use-serde"] }
+ddk-manager = { version = "1.0.7", path = "../ddk-manager", features = ["use-serde"] }
+ddk-dlc = { version = "1.0.7", path = "../dlc", features = ["use-serde"] }
+ddk-messages = { version = "1.0.7", path = "../dlc-messages", features = ["use-serde"] }
+ddk-trie = { version = "1.0.7", path = "../dlc-trie", features = ["use-serde"] }
 
 bitcoin = "0.32.6"
 serde = { version = "1.0.209", features = ["derive"] }


### PR DESCRIPTION
Release version 1.0.7

## Changes
- Updated all crate versions to 1.0.7
- Published crates to crates.io

## Release Notes
See releases/1.0.7-RELEASE.md