### PR TITLE
Zmq blockhash notifications

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,4 +10,5 @@ ESPLORA_HOST=http://localhost:30000
 BITCOIND_USER=dlcdevkit
 BITCOIND_PASS=dlcdevkit
 BITCOIND_HOST=http://localhost:18443
+ZMQ_BLOCKHASH_ENDPOINT=tcp://localhost:28334
 RPC_WALLET=ddk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +988,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "zeromq",
 ]
 
 [[package]]
@@ -3254,6 +3268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "saa"
+version = "5.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0ba8adb63e0deebd0744d8fc5bea394c08029159deaf680513fec1a3949144"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,6 +3289,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "3.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd9d1727de391b6982925d830baad51692fa2aa6e337733c03d95121ca2793"
+dependencies = [
+ "saa",
+ "sdd",
 ]
 
 [[package]]
@@ -3307,6 +3337,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25da4ae64b24edfcb0b0d30b96b2b0dbc64ec63aefeb6ec35bfc5ef167e5c9e"
 
 [[package]]
 name = "secp256k1"
@@ -4126,6 +4162,7 @@ checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5064,6 +5101,30 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zeromq"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32e1e46c4e278efd0c1153f2db0113924b9bc5fff9f9221853d035e2d26fadf"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "rand 0.9.2",
+ "regex",
+ "scc",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can create a custom DDK instance by implementing the required traits defined
 A bitcoin node, esplora server, and oracle server are required to run DDK. Developers can spin up a development environment with the `justfile` provided.
 
 ```
+$ cp .env.example .env
 $ just deps
 ```
 

--- a/ddk-node/src/lib.rs
+++ b/ddk-node/src/lib.rs
@@ -97,7 +97,7 @@ impl DdkNode {
         builder.set_oracle(oracle.clone());
         builder.set_logger(logger.clone());
 
-        if let Some(endpoint) = opts.zmq_blockhash_endpoint {
+        if let Some(endpoint) = opts.zmq_blockhash_endpoint.filter(|e| !e.is_empty()) {
             builder.set_zmq_blockhash_endpoint(endpoint);
         }
 

--- a/ddk-node/src/lib.rs
+++ b/ddk-node/src/lib.rs
@@ -55,7 +55,7 @@ impl DdkNode {
     pub async fn serve(opts: NodeOpts) -> anyhow::Result<()> {
         let logger = Arc::new(Logger::console(
             "console_logger".to_string(),
-            LogLevel::Info,
+            LogLevel::from(opts.log),
         ));
         let storage_path = match opts.storage_dir {
             Some(storage) => storage,

--- a/ddk-node/src/lib.rs
+++ b/ddk-node/src/lib.rs
@@ -97,6 +97,10 @@ impl DdkNode {
         builder.set_oracle(oracle.clone());
         builder.set_logger(logger.clone());
 
+        if let Some(endpoint) = opts.zmq_blockhash_endpoint {
+            builder.set_zmq_blockhash_endpoint(endpoint);
+        }
+
         let ddk: Ddk = builder.finish().await?;
 
         ddk.start()?;

--- a/ddk-node/src/opts.rs
+++ b/ddk-node/src/opts.rs
@@ -54,6 +54,6 @@ pub struct NodeOpts {
     #[arg(help = "Url for the postgres database connection.")]
     pub postgres_url: String,
     #[arg(long)]
-    #[arg(help = "Endpoint for bitcoind ZeroMQ blockhash notfications")]
+    #[arg(help = "Endpoint for bitcoind ZeroMQ blockhash notifications")]
     pub zmq_blockhash_endpoint: Option<String>,
 }

--- a/ddk-node/src/opts.rs
+++ b/ddk-node/src/opts.rs
@@ -53,4 +53,7 @@ pub struct NodeOpts {
     #[arg(long)]
     #[arg(help = "Url for the postgres database connection.")]
     pub postgres_url: String,
+    #[arg(long)]
+    #[arg(help = "Endpoint for bitcoind ZeroMQ blockhash notfications")]
+    pub zmq_blockhash_endpoint: Option<String>,
 }

--- a/ddk/Cargo.toml
+++ b/ddk/Cargo.toml
@@ -64,6 +64,9 @@ sha2 = "0.10"
 nostr-database = { version = "0.40.0", optional = true }
 bip39 = "2.2.0"
 
+# zmq feature
+zeromq = "0.5.0"
+
 [dev-dependencies]
 test-log = { version = "0.2.16", features = ["trace"] }
 ddk-payouts = { path = "../payouts/" }

--- a/ddk/src/builder.rs
+++ b/ddk/src/builder.rs
@@ -288,7 +288,9 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
         });
 
         let zmq_client = if let Some(endpoint) = &self.zmq_blockhash_endpoint {
-            Some(Arc::new(ZeromqClient::new(endpoint, logger.clone()).await?))
+            Some(Arc::new(
+                ZeromqClient::new(endpoint, logger.clone(), stop_signal.clone()).await?,
+            ))
         } else {
             None
         };

--- a/ddk/src/builder.rs
+++ b/ddk/src/builder.rs
@@ -120,7 +120,7 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
         self
     }
 
-    /// Set the esplora server to connect to.
+    /// Set the bitcoind server to connect to.
     pub fn set_zmq_blockhash_endpoint(&mut self, endpoint: impl ToString) -> &mut Self {
         self.zmq_blockhash_endpoint = Some(endpoint.to_string());
         self

--- a/ddk/src/builder.rs
+++ b/ddk/src/builder.rs
@@ -7,7 +7,7 @@ use ddk_manager::SystemTimeProvider;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use crate::chain::EsploraClient;
+use crate::chain::{EsploraClient, ZeromqClient};
 use crate::ddk::{DlcDevKit, DlcManagerMessage};
 use crate::error::{BuilderError, Error};
 use crate::logger::{LogLevel, Logger};
@@ -39,6 +39,7 @@ pub struct Builder<T, S, O> {
     oracle: Option<Arc<O>>,
     contract_address_generator: Option<Arc<dyn AddressGenerator + Send + Sync + 'static>>,
     esplora_host: String,
+    zmq_blockhash_endpoint: Option<String>,
     network: Network,
     seed_bytes: [u8; 64],
     logger: Option<Arc<Logger>>,
@@ -58,6 +59,7 @@ impl<T: Transport, S: Storage, O: Oracle> Default for Builder<T, S, O> {
             oracle: None,
             contract_address_generator: None,
             esplora_host: DEFAULT_ESPLORA_HOST.to_string(),
+            zmq_blockhash_endpoint: None,
             network: DEFAULT_NETWORK,
             seed_bytes: [0u8; 64],
             logger: None,
@@ -115,6 +117,12 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
     /// Set the esplora server to connect to.
     pub fn set_esplora_host(&mut self, host: String) -> &mut Self {
         self.esplora_host = host;
+        self
+    }
+
+    /// Set the esplora server to connect to.
+    pub fn set_zmq_blockhash_endpoint(&mut self, endpoint: impl ToString) -> &mut Self {
+        self.zmq_blockhash_endpoint = Some(endpoint.to_string());
         self
     }
 
@@ -279,14 +287,21 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
             }
         });
 
+        let zmq_client = if let Some(endpoint) = &self.zmq_blockhash_endpoint {
+            Some(Arc::new(ZeromqClient::new(endpoint, logger.clone()).await?))
+        } else {
+            None
+        };
+
         log_info!(
             logger.clone(),
-            "DDK runtime created. name={}, esplora={}, network={}, transport={}, oracle={}",
+            "DDK runtime created. name={}, esplora={}, network={}, transport={}, oracle={}, zmq_enabled={}",
             name,
             self.esplora_host,
             self.network,
             transport.name(),
-            oracle.get_public_key()
+            oracle.get_public_key(),
+            zmq_client.is_some()
         );
 
         Ok(DlcDevKit {
@@ -301,6 +316,7 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
             stop_signal,
             stop_signal_sender,
             logger,
+            zmq_client,
         })
     }
 }

--- a/ddk/src/chain/mod.rs
+++ b/ddk/src/chain/mod.rs
@@ -1,3 +1,5 @@
 mod esplora;
+mod zmq;
 
 pub use esplora::EsploraClient;
+pub use zmq::ZeromqClient;

--- a/ddk/src/chain/mod.rs
+++ b/ddk/src/chain/mod.rs
@@ -2,4 +2,4 @@ mod esplora;
 mod zmq;
 
 pub use esplora::EsploraClient;
-pub use zmq::ZeromqClient;
+pub use zmq::{ZeromqClient, ZeromqMessage};

--- a/ddk/src/chain/zmq.rs
+++ b/ddk/src/chain/zmq.rs
@@ -1,0 +1,119 @@
+use crate::error::Error;
+use crate::logger::{log_error, log_info, log_warn};
+use bitcoin::hashes::sha256d::Hash;
+use bitcoin::BlockHash;
+use lightning::log_debug;
+use lightning::util::logger::Logger;
+use std::sync::Arc;
+use tokio::select;
+use tokio::sync::watch;
+use zeromq::prelude::*;
+use zeromq::SubSocket;
+
+const HASH_BLOCK_TOPIC: &str = "hashblock";
+
+#[derive(Debug, Clone)]
+pub enum ZeromqMessage {
+    NewBlock(BlockHash),
+}
+
+impl ZeromqMessage {
+    fn init_dummy() -> Self {
+        Self::new_blockhash([0u8; 32])
+    }
+
+    fn new_blockhash(data: [u8; 32]) -> Self {
+        let hash = Hash::from_bytes_ref(&data);
+        let blockhash = BlockHash::from_raw_hash(*hash);
+        ZeromqMessage::NewBlock(blockhash)
+    }
+}
+
+impl std::fmt::Display for ZeromqMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NewBlock(blockhash) => write!(f, "New block found: {blockhash}"),
+        }
+    }
+}
+
+pub struct ZeromqClient {
+    logger: Arc<dyn Logger + Send + Sync>,
+    sender: watch::Sender<ZeromqMessage>,
+}
+
+impl ZeromqClient {
+    pub async fn new(endpoint: &str, logger: Arc<dyn Logger + Send + Sync>) -> Result<Self, Error> {
+        let mut socket = SubSocket::new();
+        socket.connect(endpoint).await?;
+
+        // Any subscribers created will consider the first value read. Essentially it will be
+        // ignored. So putting a dummy message in here prevents us from needing to know what
+        // the current block height is on startup.
+        let (sender, _) = watch::channel(ZeromqMessage::init_dummy());
+
+        let sender_clone = sender.clone();
+        let logger_clone = logger.clone();
+        tokio::spawn(async move { listen_and_notify(socket, sender_clone, logger_clone).await });
+
+        Ok(Self { logger, sender })
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<ZeromqMessage> {
+        log_debug!(self.logger, "Adding ZMQ notification subscriber");
+        self.sender.subscribe()
+    }
+}
+
+impl std::fmt::Debug for ZeromqClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZeromqClient")
+            // The other fields don't implement debug
+            .field("sender", &self.sender)
+            .finish()
+    }
+}
+
+async fn listen_and_notify(
+    mut socket: SubSocket,
+    sender: watch::Sender<ZeromqMessage>,
+    logger: Arc<dyn Logger + Send + Sync>,
+) -> Result<(), Error> {
+    log_info!(logger, "Starting ZMQ subscriber loop");
+    socket.subscribe(HASH_BLOCK_TOPIC).await?;
+
+    loop {
+        select! {
+            message = socket.recv() => {
+                let message = match message {
+                    Ok(message) => message,
+                    Err(err) => {
+                        log_error!(logger, "Error received from ZMQ: {}", err);
+                        continue;
+                    }
+                };
+                log_debug!(logger, "ZMQ message received: {:?}", message);
+
+                let Some(body) = message.get(1) else {
+                    log_error!(logger, "Message from ZMQ did not contain a body: {:?}", message);
+                    continue;
+                };
+                if body.len() != 32 {
+                    log_warn!(logger, "Message from ZMQ was not 32-bytes: {}", body.len());
+                    continue;
+                }
+                // From https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md#hashblock
+                // The body is a "32-byte block hash in reversed byte order."
+                let mut hash = [0u8; 32];
+                hash.copy_from_slice(body);
+                hash.reverse();
+                let message = ZeromqMessage::new_blockhash(hash);
+
+                match sender.send(message.clone()) {
+                    Ok(_) => log_debug!(logger, "Blockhash {} sucessfully sent from ZMQ client", message),
+                    Err(err) => log_warn!(logger, "New block notification failed due to no active receivers: {}", err)
+                };
+            }
+        }
+    }
+}

--- a/ddk/src/chain/zmq.rs
+++ b/ddk/src/chain/zmq.rs
@@ -129,7 +129,7 @@ async fn listen_and_notify(
 
                 let blockhash = hex::encode(hash);
                 match handle_message_body(hash, &sender) {
-                    Ok(_) => log_debug!(logger, "Blockhash {} sucessfully sent from ZMQ client", blockhash),
+                    Ok(_) => log_debug!(logger, "Blockhash {} successfully sent from ZMQ client", blockhash),
                     Err(err) => log_warn!(logger, "New block notification failed due to no active receivers: {}", err)
                 };
             }

--- a/ddk/src/chain/zmq.rs
+++ b/ddk/src/chain/zmq.rs
@@ -112,7 +112,6 @@ async fn listen_and_notify(
                         continue;
                     }
                 };
-                log_debug!(logger, "ZMQ message received: {:?}", message);
 
                 let Some(body) = message.get(1) else {
                     log_error!(logger, "Message from ZMQ did not contain a body: {:?}", message);

--- a/ddk/src/chain/zmq.rs
+++ b/ddk/src/chain/zmq.rs
@@ -7,12 +7,13 @@ use lightning::util::logger::Logger;
 use std::sync::Arc;
 use tokio::select;
 use tokio::sync::watch;
+use tokio::sync::watch::error::SendError;
 use zeromq::prelude::*;
 use zeromq::SubSocket;
 
 const HASH_BLOCK_TOPIC: &str = "hashblock";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ZeromqMessage {
     NewBlock(BlockHash),
 }
@@ -125,14 +126,50 @@ async fn listen_and_notify(
                 // The body is a "32-byte block hash in reversed byte order."
                 let mut hash = [0u8; 32];
                 hash.copy_from_slice(body);
-                hash.reverse();
-                let message = ZeromqMessage::new_blockhash(hash);
 
-                match sender.send(message.clone()) {
-                    Ok(_) => log_debug!(logger, "Blockhash {} sucessfully sent from ZMQ client", message),
+                let blockhash = hex::encode(hash);
+                match handle_message_body(hash, &sender) {
+                    Ok(_) => log_debug!(logger, "Blockhash {} sucessfully sent from ZMQ client", blockhash),
                     Err(err) => log_warn!(logger, "New block notification failed due to no active receivers: {}", err)
                 };
             }
         }
+    }
+}
+
+fn handle_message_body(
+    mut body: [u8; 32],
+    sender: &watch::Sender<ZeromqMessage>,
+) -> Result<(), SendError<ZeromqMessage>> {
+    body.reverse();
+    let message = ZeromqMessage::new_blockhash(body);
+
+    sender.send(message.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_message_body_blockhash() {
+        let body: [u8; 32] =
+            hex::decode("0000000000000000000152c5a30d731fdce51fe8c07d5cf227015b386188e5a2")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let (sender, receiver) = watch::channel(ZeromqMessage::init_dummy());
+
+        handle_message_body(body, &sender).unwrap();
+
+        let body: [u8; 32] =
+            hex::decode("a2e58861385b0127f25c7dc0e81fe5dc1f730da3c55201000000000000000000")
+                .unwrap()
+                .try_into()
+                .unwrap();
+        let expected = ZeromqMessage::new_blockhash(body);
+
+        assert!(receiver.has_changed().unwrap());
+        assert_eq!(expected, *receiver.borrow());
     }
 }

--- a/ddk/src/chain/zmq.rs
+++ b/ddk/src/chain/zmq.rs
@@ -43,7 +43,11 @@ pub struct ZeromqClient {
 }
 
 impl ZeromqClient {
-    pub async fn new(endpoint: &str, logger: Arc<dyn Logger + Send + Sync>) -> Result<Self, Error> {
+    pub async fn new(
+        endpoint: &str,
+        logger: Arc<dyn Logger + Send + Sync>,
+        stop: watch::Receiver<bool>,
+    ) -> Result<Self, Error> {
         let mut socket = SubSocket::new();
         socket.connect(endpoint).await?;
 
@@ -54,7 +58,9 @@ impl ZeromqClient {
 
         let sender_clone = sender.clone();
         let logger_clone = logger.clone();
-        tokio::spawn(async move { listen_and_notify(socket, sender_clone, logger_clone).await });
+        tokio::spawn(
+            async move { listen_and_notify(socket, sender_clone, logger_clone, stop).await },
+        );
 
         Ok(Self { logger, sender })
     }
@@ -78,12 +84,17 @@ async fn listen_and_notify(
     mut socket: SubSocket,
     sender: watch::Sender<ZeromqMessage>,
     logger: Arc<dyn Logger + Send + Sync>,
+    mut stop: watch::Receiver<bool>,
 ) -> Result<(), Error> {
     log_info!(logger, "Starting ZMQ subscriber loop");
     socket.subscribe(HASH_BLOCK_TOPIC).await?;
 
     loop {
         select! {
+            _ = stop.changed() => {
+                log_info!(logger, "ZMQ client received stop signal. Exiting.");
+                return Ok(());
+            }
             message = socket.recv() => {
                 let message = match message {
                     Ok(message) => message,

--- a/ddk/src/chain/zmq.rs
+++ b/ddk/src/chain/zmq.rs
@@ -85,15 +85,23 @@ async fn listen_and_notify(
     sender: watch::Sender<ZeromqMessage>,
     logger: Arc<dyn Logger + Send + Sync>,
     mut stop: watch::Receiver<bool>,
-) -> Result<(), Error> {
+) {
     log_info!(logger, "Starting ZMQ subscriber loop");
-    socket.subscribe(HASH_BLOCK_TOPIC).await?;
+    if let Err(err) = socket.subscribe(HASH_BLOCK_TOPIC).await {
+        log_error!(
+            logger,
+            "Error subscribing to the ZMQ {} topic: {}",
+            HASH_BLOCK_TOPIC,
+            err
+        );
+        return;
+    }
 
     loop {
         select! {
             _ = stop.changed() => {
                 log_info!(logger, "ZMQ client received stop signal. Exiting.");
-                return Ok(());
+                break;
             }
             message = socket.recv() => {
                 let message = match message {

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -25,10 +25,10 @@
 //! - Bitcoin wallet operations
 //! - DLC contract management
 
-use crate::chain::EsploraClient;
+use crate::chain::{EsploraClient, ZeromqClient};
 use crate::error::Error;
 use crate::logger::Logger;
-use crate::logger::{log_error, log_info, log_warn, WriteLog};
+use crate::logger::{log_debug, log_error, log_info, log_warn, WriteLog};
 use crate::wallet::DlcDevKitWallet;
 use crate::{Oracle, Storage, Transport};
 use bitcoin::hex::DisplayHex;
@@ -45,6 +45,7 @@ use ddk_messages::{AcceptDlc, Message, OfferDlc};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::runtime::Runtime;
+use tokio::select;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
@@ -149,6 +150,8 @@ pub struct DlcDevKit<T: Transport, S: Storage, O: Oracle> {
     pub stop_signal_sender: watch::Sender<bool>,
     /// Logger instance for structured logging
     pub logger: Arc<Logger>,
+    /// Optional ZeroMQ client for blockhash notifications
+    pub zmq_client: Option<Arc<ZeromqClient>>,
 }
 
 impl<T, S, O> DlcDevKit<T, S, O>
@@ -224,10 +227,28 @@ where
         // Spawn wallet sync thread (60-second interval)
         let wallet_clone = self.wallet.clone();
         let logger_clone = self.logger.clone();
+        let zmq_clone = self.zmq_client.clone();
         runtime.spawn(async move {
-            let mut timer = tokio::time::interval(Duration::from_secs(60));
+            // If ZMQ is configured, we want to wait to poll for a new block. We don't want to
+            // completely remove polling since it acts as backup in case ZMQ messages are missed
+            let wait_time = if zmq_clone.is_some() { 300 } else { 60 };
             loop {
-                timer.tick().await;
+                let sleep = tokio::time::sleep(Duration::from_secs(wait_time));
+                if let Some(zmq_client) = &zmq_clone {
+                    log_debug!(
+                        logger_clone,
+                        "Listening for ZMQ notifications or sleep completion"
+                    );
+                    let mut new_block = zmq_client.subscribe();
+                    select! {
+                        _ = new_block.changed() => {},
+                        _ = sleep => {}
+                    }
+                } else {
+                    log_debug!(logger_clone, "Listening for sleep completion");
+                    sleep.await;
+                }
+
                 if let Err(e) = wallet_clone.sync().await {
                     log_warn!(logger_clone, "Did not sync wallet. error={}", e.to_string());
                 };
@@ -237,10 +258,28 @@ where
         // Spawn contract monitor thread (30-second interval)
         let processor = self.sender.clone();
         let logger_clone = self.logger.clone();
+        let zmq_clone = self.zmq_client.clone();
         runtime.spawn(async move {
-            let mut timer = tokio::time::interval(Duration::from_secs(30));
+            // If ZMQ is configured, we want to wait to poll for a new block. We don't want to
+            // completely remove polling since it acts as backup in case ZMQ messages are missed
+            let wait_time = if zmq_clone.is_some() { 150 } else { 30 };
             loop {
-                timer.tick().await;
+                let sleep = tokio::time::sleep(Duration::from_secs(wait_time));
+                if let Some(zmq_client) = &zmq_clone {
+                    log_debug!(
+                        logger_clone,
+                        "Listening for ZMQ notifications or sleep completion"
+                    );
+                    let mut new_block = zmq_client.subscribe();
+                    select! {
+                        _ = new_block.changed() => {},
+                        _ = sleep => {}
+                    }
+                } else {
+                    log_debug!(logger_clone, "Listening for sleep completion");
+                    sleep.await;
+                }
+
                 let _ = processor
                     .send(DlcManagerMessage::PeriodicCheck)
                     .await

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -226,66 +226,38 @@ where
 
         // Spawn wallet sync thread (60-second interval)
         let wallet_clone = self.wallet.clone();
-        let logger_clone = self.logger.clone();
-        let zmq_clone = self.zmq_client.clone();
+        let logger = self.logger.clone();
+        let zmq = self.zmq_client.clone();
         runtime.spawn(async move {
             // If ZMQ is configured, we want to wait to poll for a new block. We don't want to
             // completely remove polling since it acts as backup in case ZMQ messages are missed
-            let wait_time = if zmq_clone.is_some() { 300 } else { 60 };
+            let wait_time = if zmq.is_some() { 300 } else { 60 };
             loop {
-                let sleep = tokio::time::sleep(Duration::from_secs(wait_time));
-                if let Some(zmq_client) = &zmq_clone {
-                    log_debug!(
-                        logger_clone,
-                        "Listening for ZMQ notifications or sleep completion"
-                    );
-                    let mut new_block = zmq_client.subscribe();
-                    select! {
-                        _ = new_block.changed() => {},
-                        _ = sleep => {}
-                    }
-                } else {
-                    log_debug!(logger_clone, "Listening for sleep completion");
-                    sleep.await;
-                }
+                wait(&zmq, wait_time, logger.clone()).await;
 
                 if let Err(e) = wallet_clone.sync().await {
-                    log_warn!(logger_clone, "Did not sync wallet. error={}", e.to_string());
+                    log_warn!(logger, "Did not sync wallet. error={}", e.to_string());
                 };
             }
         });
 
         // Spawn contract monitor thread (30-second interval)
         let processor = self.sender.clone();
-        let logger_clone = self.logger.clone();
-        let zmq_clone = self.zmq_client.clone();
+        let logger = self.logger.clone();
+        let zmq = self.zmq_client.clone();
         runtime.spawn(async move {
             // If ZMQ is configured, we want to wait to poll for a new block. We don't want to
             // completely remove polling since it acts as backup in case ZMQ messages are missed
-            let wait_time = if zmq_clone.is_some() { 150 } else { 30 };
+            let wait_time = if zmq.is_some() { 150 } else { 30 };
             loop {
-                let sleep = tokio::time::sleep(Duration::from_secs(wait_time));
-                if let Some(zmq_client) = &zmq_clone {
-                    log_debug!(
-                        logger_clone,
-                        "Listening for ZMQ notifications or sleep completion"
-                    );
-                    let mut new_block = zmq_client.subscribe();
-                    select! {
-                        _ = new_block.changed() => {},
-                        _ = sleep => {}
-                    }
-                } else {
-                    log_debug!(logger_clone, "Listening for sleep completion");
-                    sleep.await;
-                }
+                wait(&zmq, wait_time, logger.clone()).await;
 
                 let _ = processor
                     .send(DlcManagerMessage::PeriodicCheck)
                     .await
                     .map_err(|e| {
                         log_error!(
-                            logger_clone,
+                            logger,
                             "Error sending periodic check: error={}",
                             e.to_string()
                         );
@@ -452,5 +424,23 @@ where
             contract: contract.to_owned(),
             contract_pnl: contract_pnl.to_owned().to_sat(),
         })
+    }
+}
+
+async fn wait(zmq: &Option<Arc<ZeromqClient>>, wait_time: u64, logger: Arc<Logger>) {
+    let sleep = tokio::time::sleep(Duration::from_secs(wait_time));
+    if let Some(zmq_client) = zmq {
+        log_debug!(
+            logger,
+            "Listening for ZMQ notifications or sleep completion"
+        );
+        let mut new_block = zmq_client.subscribe();
+        select! {
+            _ = new_block.changed() => {},
+            _ = sleep => {}
+        }
+    } else {
+        log_debug!(logger, "Listening for sleep completion");
+        sleep.await;
     }
 }

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -25,7 +25,7 @@
 //! - Bitcoin wallet operations
 //! - DLC contract management
 
-use crate::chain::{EsploraClient, ZeromqClient};
+use crate::chain::{EsploraClient, ZeromqClient, ZeromqMessage};
 use crate::error::Error;
 use crate::logger::Logger;
 use crate::logger::{log_debug, log_error, log_info, log_warn, WriteLog};
@@ -232,8 +232,9 @@ where
             // If ZMQ is configured, we want to wait to poll for a new block. We don't want to
             // completely remove polling since it acts as backup in case ZMQ messages are missed
             let wait_time = if zmq.is_some() { 300 } else { 60 };
+            let mut new_block = zmq.map(|z| z.subscribe());
             loop {
-                wait(&zmq, wait_time, logger.clone()).await;
+                wait(&mut new_block, wait_time, logger.clone()).await;
 
                 if let Err(e) = wallet_clone.sync().await {
                     log_warn!(logger, "Did not sync wallet. error={}", e.to_string());
@@ -249,8 +250,9 @@ where
             // If ZMQ is configured, we want to wait to poll for a new block. We don't want to
             // completely remove polling since it acts as backup in case ZMQ messages are missed
             let wait_time = if zmq.is_some() { 150 } else { 30 };
+            let mut new_block = zmq.map(|z| z.subscribe());
             loop {
-                wait(&zmq, wait_time, logger.clone()).await;
+                wait(&mut new_block, wait_time, logger.clone()).await;
 
                 let _ = processor
                     .send(DlcManagerMessage::PeriodicCheck)
@@ -427,14 +429,17 @@ where
     }
 }
 
-async fn wait(zmq: &Option<Arc<ZeromqClient>>, wait_time: u64, logger: Arc<Logger>) {
+async fn wait(
+    new_block: &mut Option<watch::Receiver<ZeromqMessage>>,
+    wait_time: u64,
+    logger: Arc<Logger>,
+) {
     let sleep = tokio::time::sleep(Duration::from_secs(wait_time));
-    if let Some(zmq_client) = zmq {
+    if let Some(new_block) = new_block {
         log_debug!(
             logger,
             "Listening for ZMQ notifications or sleep completion"
         );
-        let mut new_block = zmq_client.subscribe();
         select! {
             _ = new_block.changed() => {},
             _ = sleep => {}

--- a/ddk/src/error.rs
+++ b/ddk/src/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     #[cfg(feature = "nostr")]
     #[error("NostrError: {0}")]
     Nostr(#[from] NostrError),
+    #[error("ZmqError: {0}")]
+    Zmq(#[from] zeromq::ZmqError),
 }
 
 /// Errors related to storage operations in DDK.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,12 +15,14 @@ services:
       -txindex=1
       -zmqpubrawblock=tcp://0.0.0.0:28332
       -zmqpubrawtx=tcp://0.0.0.0:28333
+      -zmqpubhashblock=tcp://0.0.0.0:28334
       -printtoconsole
       -regtest
       -disablewallet=0
     ports:
       # regtest ports
       - 18443:18443
+      - 28334:28334
     volumes:
       - ddk-bitcoin:/bitcoin/.bitcoin
   electrs:
@@ -63,7 +65,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=$POSTGRES_PASS
       - POSTGRES_USER=$POSTGRES_USER
-      
+
     ports:
       - "5432:5432"
     volumes:

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ node-one:
   - cargo run --bin ddk-node -- --network regtest --esplora $ESPLORA_HOST --name node-one --postgres-url postgres://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST/ddk_one --log debug --zmq-blockhash-endpoint $ZMQ_BLOCKHASH_ENDPOINT
 
 node-two:
-  - cargo run --bin ddk-node -- --network regtest --esplora $ESPLORA_HOST --port 1777 --grpc 0.0.0.0:3031 --storage-dir ~/.ddk/node-two --name node-two --postgres-url postgres://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST/ddk_two --log debug
+  - cargo run --bin ddk-node -- --network regtest --esplora $ESPLORA_HOST --port 1777 --grpc 0.0.0.0:3031 --storage-dir ~/.ddk/node-two --name node-two --postgres-url postgres://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST/ddk_two --log debug --zmq-blockhash-endpoint $ZMQ_BLOCKHASH_ENDPOINT
 
 cli-one *args:
   - cargo run --bin ddk-cli {{args}}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 set dotenv-load
-set dotenv-path := ".env" 
+set dotenv-path := ".env"
 
 
 deps:
@@ -12,7 +12,7 @@ echo:
   - echo $DATABASE_URL
 
 node-one:
-  - cargo run --bin ddk-node -- --network regtest --esplora $ESPLORA_HOST --name node-one --postgres-url postgres://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST/ddk_one --log debug
+  - cargo run --bin ddk-node -- --network regtest --esplora $ESPLORA_HOST --name node-one --postgres-url postgres://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST/ddk_one --log debug --zmq-blockhash-endpoint $ZMQ_BLOCKHASH_ENDPOINT
 
 node-two:
   - cargo run --bin ddk-node -- --network regtest --esplora $ESPLORA_HOST --port 1777 --grpc 0.0.0.0:3031 --storage-dir ~/.ddk/node-two --name node-two --postgres-url postgres://$POSTGRES_USER:$POSTGRES_PASS@$POSTGRES_HOST/ddk_two --log debug


### PR DESCRIPTION
This PR adds the ability for a node to listen on a bitcoind blockhash ZeroMQ endpoint and force a wallet sync and contract monitor check.

## Current setup

The wallet syncs and contract monitor checks are executed on a set interval; 60 seconds for the wallet syncs and 30 seconds for contract checks. This is fine and functions well. However, if a block (or multiple) are found in that time frame, the node won't pick it up until at least that interval has completed again. This results in an unnecessary lag between block mining and node state updating. 

## New ZMQ integration

This PR adds the ability for a node to configure a ZMQ blockhash notification endpoint on a local bitcoind node. This allows the software to know immediately when a new block is found and sync right when that notification is seen. In local testing with a regtest node, the notification of a new block was immediate, no lag. 

This could be implemented with a feature flag in Cargo. I figured doing it without one is okay for now since that feature flag would infect the code base quite a bit. If it's desired, I can add that in.

## Configuration updates

The DDK builder now has a `set_zmq_blockhash_endpoint` for setting this endpoint. In addition, the `ddk-node` has a `zmq-blockhash-endpoint` flag that ends up setting the DDK builder flag under the hood. `node-one` in the `justfile` has been updated to have this turned on. Because we are using the `zmqpubhashblock` and not `zmqpubrawblock`, I needed to add that flag to the bitcoind node's configuration in the `docker-compose.yaml` file. 

> Note:  `zmqpubhashblock` was chosen instead of `zmqpubrawblock` since this particular story was more concerned with the timing of the syncing and less removing HTTP requests entirely in the syncing process. Receiving and parsing an entire block seemed wasteful when we really only wanted to know the new block was received. There is a future where the `zmqpubrawblock` is used entirely and that block is propagated through the system. However, due to the EsploraClient's internal clients leaking out in certain areas, that would be a much larger refactor. I started down that road and retreated.

## Fallback

The default is the existing behavior. The ZMQ stuff is only used when configured to be on. When the feature is being used, the polling is still there. However, the polling times are much larger in-between polls and are there as a backup in-case something happened with the ZMQ connection. That said, ZMQ is _supposed_ to be self-healing as I understand it. 

## Testing

Local testing was done with the following process:

1. Run `just deps` 
1. Login to the local database and run `CREATE DATABASE ddk; CREATE DATABASE ddk_one; CREATE DATABASE ddk_two;`. These databases weren't autocreated.
1. Create the wallet with `just bc createwallet ddk`
1. Mine some blocks with `just bc generatetoaddress 101 $(just bc getnewaddress)`
1. Spin up node one with `just node-one`.
1. In another terminal, mine another block and observe the logs : `just bc generatetoaddress 1 $(just bc getnewaddress)`
> Note: I used `log_info` when testing since the `debug` logs didn't seem to be coming out, and I didn't spend much time debugging that. I changed most of those logs back to `log_debug` once I confirmed things work.