### PR TITLE
chore: release 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "ddk"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-dlc"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-manager"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-messages"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-node"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-payouts"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-trie"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "kormir"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["ddk", "dlc", "dlc-messages", "dlc-trie", "payouts", "ddk-node", "ddk-manager", "kormir"]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/bennyhodl/dlcdevkit"


### PR DESCRIPTION
Release version 1.1.1

## Changes
- Bumped all crate versions to 1.1.1
- Published crates to crates.io

## Release Notes
See releases/1.1.1-RELEASE.md
