### PR TITLE
chore: release 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "ddk"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-dlc"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-manager"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-messages"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-node"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-payouts"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-trie"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "kormir"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["ddk", "dlc", "dlc-messages", "dlc-trie", "payouts", "ddk-node", "ddk-manager", "kormir"]
 
 [workspace.package]
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/bennyhodl/dlcdevkit"


### PR DESCRIPTION
Release version 1.1.2

## Changes
- Bumped all crate versions to 1.1.2
- Published crates to crates.io

## Release Notes
See releases/1.1.2-RELEASE.md
