### PR TITLE
ENG-1544 add DLC accept address overrides

### DIFF
--- a/ddk-manager/src/channel_updater.rs
+++ b/ddk-manager/src/channel_updater.rs
@@ -105,6 +105,7 @@ where
         wallet,
         &signer,
         blockchain,
+        None,
     )
     .await?;
     let party_points = crate::utils::get_party_base_points(secp, signer_provider)?;
@@ -176,6 +177,7 @@ where
         wallet,
         &signer,
         blockchain,
+        None,
     )
     .await?;
 

--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -20,6 +20,7 @@ use secp256k1_zkp::{
 };
 
 use crate::dlc_input::{get_dlc_inputs_from_funding_inputs, get_signature_for_dlc_input};
+use crate::utils::PartyAddressOverride;
 use crate::Storage;
 use crate::{
     contract::{
@@ -78,6 +79,7 @@ where
         wallet,
         &signer,
         blockchain,
+        None,
     )
     .await?;
 
@@ -120,6 +122,7 @@ pub async fn accept_contract<W: Deref, X: ContractSigner, SP: Deref, B: Deref, L
     signer_provider: &SP,
     blockchain: &B,
     logger: &L,
+    address_override: Option<&PartyAddressOverride>,
 ) -> Result<(AcceptedContract, AcceptDlc), Error>
 where
     W::Target: Wallet,
@@ -140,6 +143,7 @@ where
         wallet,
         &signer,
         blockchain,
+        address_override,
     )
     .await?;
 

--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -122,6 +122,39 @@ pub async fn accept_contract<W: Deref, X: ContractSigner, SP: Deref, B: Deref, L
     signer_provider: &SP,
     blockchain: &B,
     logger: &L,
+) -> Result<(AcceptedContract, AcceptDlc), Error>
+where
+    W::Target: Wallet,
+    B::Target: Blockchain,
+    SP::Target: ContractSignerProvider<Signer = X>,
+    L::Target: Logger,
+{
+    accept_contract_with_address_override(
+        secp,
+        offered_contract,
+        wallet,
+        signer_provider,
+        blockchain,
+        logger,
+        None,
+    )
+    .await
+}
+
+/// Creates an [`AcceptedContract`] using explicit accepting-party payout and change addresses.
+pub async fn accept_contract_with_address_override<
+    W: Deref,
+    X: ContractSigner,
+    SP: Deref,
+    B: Deref,
+    L: Deref,
+>(
+    secp: &Secp256k1<All>,
+    offered_contract: &OfferedContract,
+    wallet: &W,
+    signer_provider: &SP,
+    blockchain: &B,
+    logger: &L,
     address_override: Option<&PartyAddressOverride>,
 ) -> Result<(AcceptedContract, AcceptDlc), Error>
 where

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -15,7 +15,9 @@ use crate::contract::{
     signed_contract::SignedContract, AdaptorInfo, ClosedContract, Contract, FailedAcceptContract,
     FailedSignContract, PreClosedContract,
 };
-use crate::contract_updater::{accept_contract, verify_accepted_and_sign_contract};
+use crate::contract_updater::{
+    accept_contract_with_address_override, verify_accepted_and_sign_contract,
+};
 use crate::error::Error;
 use crate::utils::{get_object_in_state, PartyAddressOverride};
 use crate::{ChannelId, ContractId, ContractSignerProvider};
@@ -490,7 +492,7 @@ where
 
         let counter_party = offered_contract.counter_party;
 
-        let (accepted_contract, accept_msg) = accept_contract(
+        let (accepted_contract, accept_msg) = accept_contract_with_address_override(
             &self.secp,
             &offered_contract,
             &self.wallet,

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -17,7 +17,7 @@ use crate::contract::{
 };
 use crate::contract_updater::{accept_contract, verify_accepted_and_sign_contract};
 use crate::error::Error;
-use crate::utils::get_object_in_state;
+use crate::utils::{get_object_in_state, PartyAddressOverride};
 use crate::{ChannelId, ContractId, ContractSignerProvider};
 use bitcoin::absolute::Height;
 use bitcoin::consensus::encode::serialize_hex;
@@ -461,6 +461,30 @@ where
         &self,
         contract_id: &ContractId,
     ) -> Result<(ContractId, PublicKey, AcceptDlc), Error> {
+        self.accept_contract_offer_with_address_override(contract_id, None)
+            .await
+    }
+
+    /// Accepts a DLC offer using explicit payout and change addresses for the accepting party.
+    pub async fn accept_contract_offer_with_addresses(
+        &self,
+        contract_id: &ContractId,
+        payout_address: Address,
+        change_address: Address,
+    ) -> Result<(ContractId, PublicKey, AcceptDlc), Error> {
+        let address_override = PartyAddressOverride {
+            payout_address,
+            change_address,
+        };
+        self.accept_contract_offer_with_address_override(contract_id, Some(&address_override))
+            .await
+    }
+
+    async fn accept_contract_offer_with_address_override(
+        &self,
+        contract_id: &ContractId,
+        address_override: Option<&PartyAddressOverride>,
+    ) -> Result<(ContractId, PublicKey, AcceptDlc), Error> {
         let offered_contract =
             get_contract_in_state!(self, contract_id, Offered, None as Option<PublicKey>)?;
 
@@ -473,6 +497,7 @@ where
             &self.signer_provider,
             &self.blockchain,
             &self.logger,
+            address_override,
         )
         .await?;
 

--- a/ddk-manager/src/utils.rs
+++ b/ddk-manager/src/utils.rs
@@ -1,7 +1,7 @@
 //! #Utils
 use std::ops::Deref;
 
-use bitcoin::{consensus::Encodable, Amount, ScriptBuf, Txid};
+use bitcoin::{consensus::Encodable, Address, Amount, ScriptBuf, Txid};
 use ddk_dlc::{dlc_input::DlcInputInfo, util::get_common_fee, PartyParams, TxInputInfo};
 use ddk_messages::{
     oracle_msgs::{OracleAnnouncement, OracleAttestation},
@@ -18,6 +18,11 @@ use crate::{
     error::Error,
     Blockchain, ContractSigner, ContractSignerProvider, Wallet,
 };
+
+pub struct PartyAddressOverride {
+    pub payout_address: Address,
+    pub change_address: Address,
+}
 
 macro_rules! get_object_in_state {
     ($manager: expr, $id: expr, $state: ident, $peer_id: expr, $object_type: ident, $get_call: ident) => {{
@@ -99,6 +104,7 @@ pub(crate) async fn get_party_params<W: Deref, B: Deref, X: ContractSigner, C: S
     wallet: &W,
     signer: &X,
     blockchain: &B,
+    address_override: Option<&PartyAddressOverride>,
 ) -> Result<(PartyParams, Vec<FundingInput>), Error>
 where
     W::Target: Wallet,
@@ -106,10 +112,16 @@ where
 {
     let funding_pubkey = signer.get_public_key(secp)?;
 
-    let payout_addr = wallet.get_new_address().await?;
+    let payout_addr = match address_override {
+        Some(address_override) => address_override.payout_address.clone(),
+        None => wallet.get_new_address().await?,
+    };
     let payout_spk = payout_addr.script_pubkey();
     let payout_serial_id = get_new_serial_id();
-    let change_addr = wallet.get_new_change_address().await?;
+    let change_addr = match address_override {
+        Some(address_override) => address_override.change_address.clone(),
+        None => wallet.get_new_change_address().await?,
+    };
     let change_spk = change_addr.script_pubkey();
     let change_serial_id = get_new_serial_id();
 


### PR DESCRIPTION
## Summary
- add an explicit accept-offer API that accepts payout and change addresses for the accepting party
- thread optional address overrides through DDK party parameter construction
- preserve existing accept_contract_offer behavior for current callers

## Verification
- cargo build via dlcd-rs using local dlcdevkit path dependency

Linear: ENG-1544