### PR TITLE
Run the test suites against managed regtest backends instead of docker compose

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,16 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The test suites manage their own bitcoind, electrs, postgres and nostr relay
+# (see the `ddk-testenv` crate), so no service containers or connection
+# environment variables are needed here.
 env:
   CARGO_TERM_COLOR: always
-  POSTGRES_USER: dlcdevkit
-  POSTGRES_PASS: dlcdevkit
-  DATABASE_URL: postgresql://dlcdevkit:dlcdevkit@localhost:5432/postgres
-  BITCOIND_HOST: http://localhost:18443
-  BITCOIND_USER: dlcdevkit
-  BITCOIND_PASS: dlcdevkit
-  ESPLORA_HOST: http://localhost:30000
-  RPC_WALLET: ddk
   NB_CONFIRMATIONS: 6
 
 jobs:
@@ -73,21 +68,13 @@ jobs:
           rustup toolchain install 1.88.0 --profile minimal
           rustup default 1.88.0
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - name: Start Docker Compose services
-        run: docker compose up -d
-      - name: Wait for Bitcoin container
-        run: |
-          chmod +x ./testconfig/scripts/wait_for_container.sh
-          ./testconfig/scripts/wait_for_container.sh bitcoin
-      - name: Wait for Electrs to be ready
-        run: |
-          chmod +x ./testconfig/scripts/wait_for_electrs.sh
-          ./testconfig/scripts/wait_for_electrs.sh
+      - name: Cache embedded postgres binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.theseus/postgresql
+          key: theseus-postgresql-${{ runner.os }}
       - name: Run unit tests
         run: cargo test --all-features
-      - name: Stop Docker Compose services
-        if: always()
-        run: docker compose down -v
   integration_tests_prepare:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -104,10 +91,16 @@ jobs:
       # rust-cache is declared first so that its post-step (which prunes target/)
       # runs AFTER the run_id cache below saves the freshly compiled test binaries.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # `target/debug/build` carries the bitcoind and electrs executables that
+      # the build scripts downloaded. The test binaries resolve them through the
+      # OUT_DIR path baked in at compile time, so both directories have to be
+      # restored together for the matrix jobs to find them.
       - name: Cache compiled test binaries for the matrix jobs
         uses: actions/cache@v4
         with:
-          path: target/debug/deps
+          path: |
+            target/debug/deps
+            target/debug/build
           key: test-cache-${{ github.run_id }}-${{ github.run_number }}
       - id: set-matrix
         run: cargo test --no-run --all-features && echo "matrix=$(testconfig/scripts/get_test_list.sh manager_execution manager_tests contract_updater)" >> "$GITHUB_OUTPUT"
@@ -123,22 +116,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:
-          path: target/debug/deps
+          path: |
+            target/debug/deps
+            target/debug/build
           key: test-cache-${{ github.run_id }}-${{ github.run_number }}
-      - name: Start bitcoin node
-        run: docker compose up -d bitcoin electrs
-      - name: Wait for container to run
-        run: |
-          chmod +x ./testconfig/scripts/wait_for_container.sh
-          ./testconfig/scripts/wait_for_container.sh bitcoin
-      - name: Wait for electrs to be ready
-        run: |
-          chmod +x ./testconfig/scripts/wait_for_electrs.sh
-          ./testconfig/scripts/wait_for_electrs.sh
       - name: Run test
         run: RUST_BACKTRACE=1 RUST_MIN_STACK=8388608 ${{ matrix.tests }} --ignored
-      - name: Stop bitcoin node
-        run: docker compose down -v
 
   test_splicing:
     name: test splicing
@@ -147,17 +130,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - name: Start bitcoin node
-        run: docker compose up -d bitcoin electrs
-      - name: Wait for container to run
-        run: |
-          chmod +x ./testconfig/scripts/wait_for_container.sh
-          ./testconfig/scripts/wait_for_container.sh bitcoin
-      - name: Wait for electrs to be ready
-        run: |
-          chmod +x ./testconfig/scripts/wait_for_electrs.sh
-          ./testconfig/scripts/wait_for_electrs.sh
       - name: Run test
         run: RUST_MIN_STACK=8388608 cargo test -p ddk-manager splice -- --nocapture --ignored
-      - name: Stop bitcoin node
-        run: docker compose down -v

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,7 +498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
 dependencies = [
  "bitcoincore-rpc-json",
- "jsonrpc",
+ "jsonrpc 0.18.0",
  "log",
  "serde",
  "serde_json",
@@ -510,6 +516,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoind"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bf8ad1dbb61cfc69dd02f5377a8a7bae5c7a299f8644ffedd0f3ea38e2e925"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes",
+ "bitreq",
+ "corepc-client",
+ "flate2",
+ "log",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "which",
+ "zip",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +547,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitreq"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
+dependencies = [
+ "rustls",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -568,6 +606,26 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cast"
@@ -803,6 +861,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "corepc-client"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349238a237f42ae84050dc449406a734a752c418b9dd531ecb4e93e7b97d094e"
+dependencies = [
+ "bitcoin",
+ "corepc-types",
+ "jsonrpc 0.20.1",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c274042a89391a324ab313b5210680969d02a9fa977733c3354aea4d7a4883"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1079,7 @@ dependencies = [
  "ddk-manager",
  "ddk-messages",
  "ddk-payouts",
+ "ddk-testenv",
  "ddk-trie",
  "dotenvy",
  "hex",
@@ -1044,6 +1128,7 @@ dependencies = [
  "ddk",
  "ddk-dlc",
  "ddk-messages",
+ "ddk-testenv",
  "ddk-trie",
  "dotenvy",
  "env_logger",
@@ -1113,6 +1198,19 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ddk-testenv"
+version = "1.1.1"
+dependencies = [
+ "bitcoin",
+ "bitcoincore-rpc",
+ "bitcoind",
+ "electrsd",
+ "libc",
+ "nostr-relay-builder",
+ "postgresql_embedded",
 ]
 
 [[package]]
@@ -1244,6 +1342,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "electrsd"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7741fbb9d8e3e65f30e4d9cd60c9a9e09a3aa530330b88dfc13468de1a8ec316"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes",
+ "bitcoind",
+ "bitreq",
+ "corepc-client",
+ "electrum-client",
+ "log",
+ "nix 0.25.1",
+ "zip",
+]
+
+[[package]]
+name = "electrum-client"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1970c5d7bd9de6d4041cbfc3e46faa3e85fe7efcea2b0eb06750d3ae1ef577b7"
+dependencies = [
+ "bitcoin",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1482,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1759,7 +1906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
 dependencies = [
  "cfg-if",
- "nix",
+ "nix 0.30.1",
  "widestring",
  "windows",
 ]
@@ -2229,6 +2376,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f106cca655869522988b976127096f0aa36e0f1a8ff1f1f425a5c85b61e59391"
+dependencies = [
+ "base64 0.22.1",
+ "bitreq",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kormir"
 version = "1.1.1"
 dependencies = [
@@ -2419,6 +2578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2601,16 @@ dependencies = [
  "bech32",
  "bitcoin",
  "serde",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2508,6 +2686,20 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2561,6 +2753,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
 dependencies = [
  "nostr",
+]
+
+[[package]]
+name = "nostr-relay-builder"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ed09e8363503c6f464087b530a1f43cf68be6292bd4928b5ea1141b03dc11c"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "hex",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2636,6 +2845,16 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"
@@ -2872,6 +3091,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3204,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "postgresql_archive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b10a6a63e5f4ccf5d99d7d5db0829aec30a5e84b5c80883f6561c77a7521a6"
+dependencies = [
+ "async-trait",
+ "flate2",
+ "futures-util",
+ "hex",
+ "num-format",
+ "regex-lite",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "reqwest-tracing",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "target-triple",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "postgresql_commands"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc8653c31df5ffcd3bc114641dfae5390404d6e22bc21fd7473760f22cdc20b"
+dependencies = [
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "postgresql_embedded"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4386829807c8dfbc190f8e53b91d2080f0f604bd4b9f0831281ccfbc06998123"
+dependencies = [
+ "anyhow",
+ "postgresql_archive",
+ "postgresql_commands",
+ "rand 0.9.4",
+ "semver",
+ "sqlx",
+ "target-triple",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3326,6 +3609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3629,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3358,12 +3648,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3405,6 +3697,68 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3845,6 +4199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3956,6 +4316,7 @@ dependencies = [
  "indexmap",
  "log",
  "memchr",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "serde",
@@ -4200,6 +4561,23 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
@@ -4888,6 +5266,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,6 +5338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5386,6 +5801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5511,6 +5936,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["ddk", "dlc", "dlc-messages", "dlc-trie", "payouts", "ddk-node", "ddk-manager", "kormir"]
+members = ["ddk", "dlc", "dlc-messages", "dlc-trie", "payouts", "ddk-node", "ddk-manager", "kormir", "testenv"]
 
 [workspace.package]
 version = "1.1.1"
@@ -19,6 +19,8 @@ ddk-trie = { version = "1.0.11", path = "dlc-trie", default-features = false }
 ddk-manager = { version = "1.0.11", path = "ddk-manager", default-features = false }
 ddk-payouts = { version = "1.0.11", path = "payouts" }
 kormir = { version = "1.0.11", path = "kormir" }
+# Path-only (no version): cargo strips it from the published manifests.
+ddk-testenv = { path = "testenv" }
 
 bitcoin = { version = "0.32.6", default-features = false }
 lightning = { version = "0.2.2", default-features = false }
@@ -48,3 +50,7 @@ chrono = "0.4.39"
 bitcoincore-rpc = "0.19.0"
 bitcoincore-rpc-json = "0.19.0"
 dotenvy = "0.15.7"
+# Managed regtest backends for integration tests. `download` fetches the
+# bitcoind / electrs binaries at build time into OUT_DIR.
+bitcoind = { version = "0.41.0", default-features = false, features = ["28_2", "download"] }
+electrsd = { version = "0.41.0", default-features = false, features = ["esplora_a33e97e1", "download"] }

--- a/README.md
+++ b/README.md
@@ -74,10 +74,38 @@ You can create a custom DDK instance by implementing the required traits defined
 
 ## Development
 
-A bitcoin node, esplora server, and oracle server are required to run DDK. Developers can spin up a development environment with the `justfile` provided.
+### Tests
+
+Tests need nothing running beforehand:
 
 ```
-$ cp .env.example .env
+$ cargo test --all-features
+```
+
+Each test binary starts and tears down its own regtest bitcoind, electrs
+(serving the esplora HTTP API), PostgreSQL server, and nostr relay on ephemeral
+ports. The bitcoind and electrs executables are downloaded once at build time by
+the [`ddk-testenv`](./testenv) crate's dependencies; PostgreSQL is fetched on
+first use and cached under `~/.theseus/postgresql`.
+
+The long-running integration tests are marked `#[ignore]`; run them with:
+
+```
+$ NB_CONFIRMATIONS=6 cargo test --all-features -- --ignored
+```
+
+`NB_CONFIRMATIONS` is not optional here. It sets the depth at which the manager
+treats a contract as confirmed, and the cooperative close tests assume 6; at the
+default of 3 they fail.
+
+### Running a node
+
+A bitcoin node, esplora server, and oracle server are required to *run* DDK
+(as opposed to testing it). Developers can spin up a development environment
+with the `justfile` provided.
+
+```
+$ cp .env.sample .env
 $ just deps
 ```
 

--- a/ddk-manager/Cargo.toml
+++ b/ddk-manager/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 ddk = { workspace = true }
+ddk-testenv = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 bitcoincore-rpc-json = { workspace = true }
 criterion = "0.8.2"

--- a/ddk-manager/tests/contract_updater.rs
+++ b/ddk-manager/tests/contract_updater.rs
@@ -4,8 +4,7 @@ mod test_utils;
 
 use std::sync::Arc;
 
-use bitcoin::{Amount, Network};
-use ddk::chain::EsploraClient;
+use bitcoin::Amount;
 use ddk::logger::Logger;
 use ddk_manager::contract::offered_contract::OfferedContract;
 use secp256k1_zkp::rand::Fill;
@@ -26,13 +25,12 @@ async fn accept_contract_test() {
         .unwrap();
     let offered_contract =
         OfferedContract::try_from_offer_dlc(&offer_dlc, dummy_pubkey, keys_id).unwrap();
-    let blockchain = Arc::new(
-        EsploraClient::new("http://localhost:30000", Network::Regtest, logger.clone()).unwrap(),
-    );
+    let env = test_utils::test_env();
+    let blockchain = test_utils::esplora_client(&env, logger.clone());
 
     let amount = Amount::from_btc(2.1).unwrap();
     let stuff =
-        test_utils::create_and_fund_wallet(logger.clone(), blockchain.clone(), amount).await;
+        test_utils::create_and_fund_wallet(&env, logger.clone(), blockchain.clone(), amount).await;
     let wallet = Arc::new(stuff.0);
     wallet.sync().await.unwrap();
 

--- a/ddk-manager/tests/manager_execution_tests.rs
+++ b/ddk-manager/tests/manager_execution_tests.rs
@@ -3,7 +3,6 @@
 mod test_utils;
 
 use bitcoin::Amount;
-use ddk::chain::EsploraClient;
 use ddk::logger::Logger;
 use ddk_manager::payout_curve::PayoutFunctionPiece;
 use test_utils::*;
@@ -727,11 +726,11 @@ async fn get_attestations(test_params: &TestParams) -> Vec<(usize, OracleAttesta
 
 async fn manager_execution_test(test_params: TestParams, path: TestPath, manual_close: bool) {
     env_logger::try_init().ok();
-    let esplora_host = std::env::var("ESPLORA_HOST").expect("ESPLORA_HOST must be set");
     let logger = Arc::new(Logger::disabled("test_manager_execution".to_string()));
-    let electrs = Arc::new(
-        EsploraClient::new(&esplora_host, bitcoin::Network::Regtest, logger.clone()).unwrap(),
-    );
+    // Held for the whole test: these assertions depend on the chain advancing
+    // only when this test mines.
+    let env = test_utils::test_env();
+    let electrs = test_utils::esplora_client(&env, logger.clone());
 
     let (alice_send, mut bob_receive) = channel::<Option<Message>>(100);
     let (bob_send, mut alice_receive) = channel::<Option<Message>>(100);
@@ -740,7 +739,7 @@ async fn manager_execution_test(test_params: TestParams, path: TestPath, manual_
     let bob_sync_send = sync_send;
     let amount = Amount::from_btc(2.1).unwrap();
     let (bob_wallet, bob_storage, alice_wallet, alice_storage, sink_rpc) =
-        init_clients(logger.clone(), electrs.clone(), amount, amount).await;
+        init_clients(&env, logger.clone(), electrs.clone(), amount, amount).await;
     let alice_wallet = Arc::new(alice_wallet);
     let bob_wallet = Arc::new(bob_wallet);
     let sink = Arc::new(sink_rpc);

--- a/ddk-manager/tests/manager_tests.rs
+++ b/ddk-manager/tests/manager_tests.rs
@@ -26,8 +26,15 @@ type TestManager = Manager<
 >;
 
 async fn get_manager(logger: Arc<Logger>) -> TestManager {
+    // These tests reject offers before anything reaches the chain and never
+    // mine, so the backends shared across this binary are enough.
     let blockchain = Arc::new(
-        EsploraClient::new("http://localhost:30000", Network::Regtest, logger.clone()).unwrap(),
+        EsploraClient::new(
+            ddk_testenv::env().esplora_host(),
+            Network::Regtest,
+            logger.clone(),
+        )
+        .unwrap(),
     );
     let store = Arc::new(MemoryStorage::new());
     let mut seed = [0u8; 64];

--- a/ddk-manager/tests/splice_execution_tests.rs
+++ b/ddk-manager/tests/splice_execution_tests.rs
@@ -1,7 +1,7 @@
 use bitcoin::Amount;
 use bitcoincore_rpc::RpcApi;
 use ddk::logger::LogLevel;
-use ddk::{chain::EsploraClient, logger::Logger, oracle::memory::MemoryOracle};
+use ddk::{logger::Logger, oracle::memory::MemoryOracle};
 use ddk_dlc::{EnumerationPayout, Payout};
 use ddk_manager::contract::Contract;
 use ddk_manager::{
@@ -40,13 +40,14 @@ async fn splice_execution_test(test_params: test_utils::TestParams) {
         "splice_execution_tests".to_string(),
         LogLevel::Debug,
     ));
-    let electrs_host = std::env::var("ESPLORA_HOST").expect("ESPLORA_HOST must be set");
-    let electrs = Arc::new(
-        EsploraClient::new(&electrs_host, bitcoin::Network::Regtest, logger.clone()).unwrap(),
-    );
+    // Held for the whole test: these assertions depend on the chain advancing
+    // only when this test mines.
+    let env = test_utils::test_env();
+    let electrs = test_utils::esplora_client(&env, logger.clone());
 
     let (alice_wallet, alice_storage, bob_wallet, bob_storage, sink_rpc) =
         test_utils::init_clients(
+            &env,
             logger.clone(),
             electrs.clone(),
             funding_collateral,

--- a/ddk-manager/tests/test_utils.rs
+++ b/ddk-manager/tests/test_utils.rs
@@ -4,7 +4,7 @@ use bitcoin::{
     consensus::{Decodable, Encodable},
     Amount, Network, Transaction,
 };
-use bitcoincore_rpc::{Auth, Client, RpcApi};
+use bitcoincore_rpc::{Client, RpcApi};
 use bitcoincore_rpc_json::AddressType;
 use ddk::{chain::EsploraClient, logger::Logger, wallet::DlcDevKitWallet};
 use ddk::{oracle::memory::MemoryOracle, storage::memory::MemoryStorage};
@@ -24,6 +24,7 @@ use ddk_manager::{
     },
     payout_curve::HyperbolaPayoutCurvePiece,
 };
+use ddk_testenv::TestEnv;
 use ddk_trie::OracleNumericInfo;
 use secp256k1_zkp::rand::{seq::SliceRandom, thread_rng, Fill, RngCore};
 use std::fmt::Write;
@@ -817,15 +818,26 @@ pub async fn refresh_wallet(wallet: &DlcDevKitWallet, expected_funds: u64) {
     }
 }
 
-pub fn rpc_client() -> Client {
-    let user = std::env::var("BITCOIND_USER").expect("BITCOIND_USER must be set");
-    let pass = std::env::var("BITCOIND_PASS").expect("BITCOIND_PASS must be set");
-    let host =
-        std::env::var("BITCOIND_HOST").unwrap_or_else(|_| "http://localhost:18443".to_owned());
-    Client::new(&host, Auth::UserPass(user, pass)).unwrap()
+/// Starts regtest backends private to one test.
+///
+/// These tests assert on contract state as blocks advance, so they cannot share
+/// a chain: blocks a sibling test mines would drive a contract past its locktime
+/// early. Every test owns its own bitcoind and electrs, and drops them at the
+/// end.
+pub fn test_env() -> TestEnv {
+    TestEnv::new()
+}
+
+/// An esplora client pointed at `env`.
+pub fn esplora_client(env: &TestEnv, logger: Arc<Logger>) -> Arc<EsploraClient> {
+    Arc::new(
+        EsploraClient::new(env.esplora_host(), Network::Regtest, logger)
+            .expect("could not build the Esplora client"),
+    )
 }
 
 pub async fn init_clients(
+    env: &TestEnv,
     logger: Arc<Logger>,
     esplora: Arc<EsploraClient>,
     offer_amount: Amount,
@@ -837,11 +849,13 @@ pub async fn init_clients(
     Arc<MemoryStorage>,
     Client,
 ) {
-    let sink_rpc = rpc_client();
+    let sink_rpc = env.rpc();
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    let offer_rpc = create_and_fund_wallet(logger.clone(), esplora.clone(), offer_amount).await;
-    let accept_rpc = create_and_fund_wallet(logger.clone(), esplora.clone(), accept_amount).await;
+    let offer_rpc =
+        create_and_fund_wallet(env, logger.clone(), esplora.clone(), offer_amount).await;
+    let accept_rpc =
+        create_and_fund_wallet(env, logger.clone(), esplora.clone(), accept_amount).await;
 
     let sink_address = sink_rpc
         .get_new_address(None, Some(AddressType::Bech32))
@@ -860,11 +874,12 @@ pub async fn init_clients(
 }
 
 pub async fn create_and_fund_wallet(
+    env: &TestEnv,
     logger: Arc<Logger>,
     esplora: Arc<EsploraClient>,
     amount: Amount,
 ) -> (DlcDevKitWallet, Arc<MemoryStorage>) {
-    let sink_rpc = rpc_client();
+    let sink_rpc = env.rpc();
     let sink_address = sink_rpc
         .get_new_address(None, None)
         .unwrap()

--- a/ddk/Cargo.toml
+++ b/ddk/Cargo.toml
@@ -72,6 +72,10 @@ test-log = { version = "0.2.16", features = ["trace"] }
 ddk-payouts = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 dotenvy = { workspace = true }
+# The `nostr`/`postgres` backends are enabled unconditionally rather than from
+# ddk's own features of the same name: a feature can't forward to a path-only
+# dev-dependency, because cargo strips that dependency when packaging.
+ddk-testenv = { workspace = true, features = ["nostr", "postgres"] }
 
 [[example]]
 name = "lightning"

--- a/ddk/src/oracle/nostr.rs
+++ b/ddk/src/oracle/nostr.rs
@@ -284,7 +284,10 @@ mod tests {
 
     use super::*;
 
-    async fn test_send_announcement(key: nostr_rs::key::Keys) -> (OracleAnnouncement, Event) {
+    async fn test_send_announcement(
+        key: nostr_rs::key::Keys,
+        relay_url: &str,
+    ) -> (OracleAnnouncement, Event) {
         let xpriv =
             Xpriv::new_master(bitcoin::Network::Regtest, &key.secret_key().secret_bytes()).unwrap();
         let storage = kormir::storage::MemoryStorage::default();
@@ -310,7 +313,7 @@ mod tests {
                 .unwrap();
 
         let nostr_client = nostr_sdk::Client::new(key);
-        nostr_client.add_relay("ws://localhost:8081").await.unwrap();
+        nostr_client.add_relay(relay_url).await.unwrap();
         nostr_client.connect().await;
         nostr_client.send_event(&ann_event).await.unwrap();
         (announcement, ann_event)
@@ -318,8 +321,10 @@ mod tests {
 
     #[tokio::test]
     async fn handle_oracle_announcement_test() {
+        // Held for the duration of the test: the relay shuts down when dropped.
+        let relay = ddk_testenv::nostr::TestRelay::start().await;
         let nostr_keys = nostr_rs::key::Keys::generate();
-        let (announcement, event) = test_send_announcement(nostr_keys).await;
+        let (announcement, event) = test_send_announcement(nostr_keys, relay.url()).await;
         let decoded = decode_base64::<OracleAnnouncement>(&event.content).unwrap();
         assert_eq!(announcement, decoded);
     }

--- a/ddk/src/storage/postgres/mod.rs
+++ b/ddk/src/storage/postgres/mod.rs
@@ -1013,12 +1013,14 @@ mod tests {
     use super::*;
     use crate::{logger::LogLevel, util::ser::deserialize_contract};
     use ddk_manager::Storage;
+    use ddk_testenv::postgres::TestPostgres;
 
-    async fn seed_db() -> PostgresStore {
-        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-        println!("database_url: {database_url}");
+    /// Returns the store alongside the server backing it: the server stops when
+    /// dropped, so the caller has to keep it alive.
+    async fn seed_db() -> (TestPostgres, PostgresStore) {
+        let server = TestPostgres::start("ddk").await;
         let store = PostgresStore::new(
-            &database_url,
+            server.url(),
             true,
             Arc::new(Logger::console(
                 "console_logger".to_string(),
@@ -1072,13 +1074,12 @@ mod tests {
             .await
             .expect("Failed to update closed contract");
 
-        store
+        (server, store)
     }
 
     #[tokio::test]
     async fn postgres() {
-        dotenvy::dotenv().ok();
-        let db = seed_db().await;
+        let (_server, db) = seed_db().await;
 
         let confirmed_rows = db.get_contract_metadata(None).await.unwrap();
         assert_eq!(confirmed_rows.len(), 1);

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -1006,7 +1006,7 @@ impl Debug for DlcDevKitWallet {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
+    use std::{collections::HashSet, str::FromStr, sync::Arc};
 
     use crate::chain::EsploraClient;
     use crate::logger::{LogLevel, Logger};
@@ -1018,13 +1018,12 @@ mod tests {
         secp256k1::{PublicKey, SecretKey},
         Address, AddressType, Amount, FeeRate, Network,
     };
-    use bitcoincore_rpc::RpcApi;
     use ddk_manager::{ContractSigner, ContractSignerProvider};
 
     use super::DlcDevKitWallet;
 
     async fn create_wallet() -> DlcDevKitWallet {
-        let esplora = std::env::var("ESPLORA_HOST").expect("ESPLORA_HOST must be set");
+        let esplora = ddk_testenv::env().esplora_host().to_string();
         let storage = Arc::new(MemoryStorage::new());
         let logger = Arc::new(Logger::console(
             "console_logger".to_string(),
@@ -1049,43 +1048,12 @@ mod tests {
     }
 
     fn generate_blocks(num: u64) {
-        let bitcoind =
-            std::env::var("BITCOIND_HOST").unwrap_or("http://localhost:18443".to_string());
-        let user = std::env::var("BITCOIND_USER").expect("BITCOIND_USER must be set");
-        let pass = std::env::var("BITCOIND_PASS").expect("BITCOIND_PASS must be set");
-        let auth = bitcoincore_rpc::Auth::UserPass(user, pass);
-        let client = bitcoincore_rpc::Client::new(&bitcoind, auth).unwrap();
-        let previous_height = client.get_block_count().unwrap();
-
-        let address = client.get_new_address(None, None).unwrap().assume_checked();
-        client.generate_to_address(num, &address).unwrap();
-        let mut cur_block_height = previous_height;
-        while cur_block_height < previous_height + num {
-            std::thread::sleep(Duration::from_secs(5));
-            cur_block_height = client.get_block_count().unwrap();
-        }
+        ddk_testenv::env().generate_blocks(num);
     }
 
     fn fund_address(address: &Address<NetworkChecked>) {
-        let bitcoind =
-            std::env::var("BITCOIND_HOST").unwrap_or("http://localhost:18443".to_string());
-        let user = std::env::var("BITCOIND_USER").expect("BITCOIND_USER must be set");
-        let pass = std::env::var("BITCOIND_PASS").expect("BITCOIND_PASS must be set");
-        let auth = bitcoincore_rpc::Auth::UserPass(user, pass);
-        let client = bitcoincore_rpc::Client::new(&bitcoind, auth).unwrap();
-        client
-            .send_to_address(
-                address,
-                Amount::from_btc(1.0).unwrap(),
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
-        generate_blocks(5)
+        ddk_testenv::env().fund_address(address, Amount::from_btc(1.0).unwrap());
+        generate_blocks(4)
     }
 
     #[tokio::test]
@@ -1585,9 +1553,9 @@ mod tests {
             "console_logger".to_string(),
             LogLevel::Info,
         ));
-        let esplora_host = std::env::var("ESPLORA_HOST").expect("ESPLORA_HOST must be set");
+        let esplora_host = ddk_testenv::env().esplora_host();
         let esplora =
-            Arc::new(EsploraClient::new(&esplora_host, Network::Regtest, logger.clone()).unwrap());
+            Arc::new(EsploraClient::new(esplora_host, Network::Regtest, logger.clone()).unwrap());
 
         let mut seed = [0u8; 64];
         seed.try_fill(&mut bitcoin::key::rand::thread_rng())

--- a/ddk/tests/nostr.rs
+++ b/ddk/tests/nostr.rs
@@ -14,29 +14,26 @@ mod nostr_test {
     use ddk::DlcDevKit;
     use ddk::{builder::Builder, Transport};
     use ddk_dlc::{EnumerationPayout, Payout};
+    use ddk_testenv::nostr::TestRelay;
     use std::sync::Arc;
 
     type NostrDlcDevKit = DlcDevKit<NostrDlc, MemoryStorage, MemoryOracle>;
 
     async fn nostr_ddk(
         name: &str,
+        relay_url: &str,
         oracle: Arc<MemoryOracle>,
         logger: Arc<Logger>,
     ) -> NostrDlcDevKit {
         let mut seed = [0u8; 64];
         seed.try_fill(&mut bitcoin::key::rand::thread_rng())
             .unwrap();
-        let esplora_host = "http://127.0.0.1:30000".to_string();
+        let esplora_host = ddk_testenv::env().esplora_host().to_string();
 
         let transport = Arc::new(
-            NostrDlc::new(
-                &seed,
-                "ws://127.0.0.1:8081",
-                Network::Regtest,
-                logger.clone(),
-            )
-            .await
-            .unwrap(),
+            NostrDlc::new(&seed, relay_url, Network::Regtest, logger.clone())
+                .await
+                .unwrap(),
         );
         let storage = Arc::new(MemoryStorage::new());
 
@@ -62,8 +59,10 @@ mod nostr_test {
     async fn nostr_contract() {
         let oracle = Arc::new(MemoryOracle::default());
         let logger = Arc::new(Logger::console("nostr-test".to_string(), LogLevel::Info));
-        let alice = nostr_ddk("alice-nostr", oracle.clone(), logger.clone()).await;
-        let bob = nostr_ddk("bob-nostr", oracle.clone(), logger.clone()).await;
+        // Held for the duration of the test: the relay shuts down when dropped.
+        let relay = TestRelay::start().await;
+        let alice = nostr_ddk("alice-nostr", relay.url(), oracle.clone(), logger.clone()).await;
+        let bob = nostr_ddk("bob-nostr", relay.url(), oracle.clone(), logger.clone()).await;
 
         let alice_address = alice.wallet.new_external_address().await.unwrap().address;
         let bob_address = bob.wallet.new_external_address().await.unwrap().address;

--- a/ddk/tests/test_util.rs
+++ b/ddk/tests/test_util.rs
@@ -62,11 +62,7 @@ pub async fn test_ddk(
 }
 
 pub fn get_bitcoind_client() -> Client {
-    let bitcoind_user = std::env::var("BITCOIND_USER").expect("BITCOIND_USER must be set");
-    let bitcoind_pass = std::env::var("BITCOIND_PASS").expect("BITCOIND_PASS must be set");
-    let bitcoind_host = std::env::var("BITCOIND_HOST").expect("BITCOIND_HOST must be set");
-    let auth = bitcoincore_rpc::Auth::UserPass(bitcoind_user, bitcoind_pass);
-    bitcoincore_rpc::Client::new(&bitcoind_host, auth).unwrap()
+    ddk_testenv::env().rpc()
 }
 
 pub fn fund_addresses(
@@ -102,16 +98,7 @@ pub fn fund_addresses(
 }
 
 pub fn generate_blocks(num: u64) {
-    let client = get_bitcoind_client();
-    let previous_height = client.get_block_count().unwrap();
-
-    let address = client.get_new_address(None, None).unwrap().assume_checked();
-    client.generate_to_address(num, &address).unwrap();
-    let mut cur_block_height = previous_height;
-    while cur_block_height < previous_height + num {
-        sleep(Duration::from_secs(5));
-        cur_block_height = client.get_block_count().unwrap();
-    }
+    ddk_testenv::env().generate_blocks(num);
 }
 
 pub struct TestSuite {
@@ -128,7 +115,7 @@ impl TestSuite {
         let mut seed = [0u8; 64];
         seed.try_fill(&mut bitcoin::key::rand::thread_rng())
             .unwrap();
-        let esplora_host = std::env::var("ESPLORA_HOST").expect("ESPLORA_HOST must be set");
+        let esplora_host = ddk_testenv::env().esplora_host().to_string();
 
         let transport = Arc::new(MemoryTransport::new(secp, logger.clone()));
         let storage = Arc::new(MemoryStorage::new());

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,7 @@
+# Development stack for *running* a ddk-node (`just deps`).
+#
+# The test suites do not use this: they start their own bitcoind, electrs,
+# postgres and nostr relay on ephemeral ports. See the `testenv` crate.
 name: "dlcdevkit"
 services:
   bitcoin:

--- a/testconfig/scripts/generate_enumeration_contract_binaries.sh
+++ b/testconfig/scripts/generate_enumeration_contract_binaries.sh
@@ -13,8 +13,7 @@ mkdir -p ${DEST}
 
 echo "Starting enumeration contract binary generation..."
 
-./testconfig/scripts/wait_for_electrs.sh
-
+# The test starts its own bitcoind and electrs, so nothing needs to be running.
 # Run the enumeration test with serialization enabled
 echo "Running enumeration test with contract serialization..."
 GENERATE_SERIALIZED_CONTRACT=1 cargo test -p ddk --test enumeration enumeration_contract -- --ignored

--- a/testconfig/scripts/setup-bitcoind.sh
+++ b/testconfig/scripts/setup-bitcoind.sh
@@ -1,3 +1,0 @@
-just bc createwallet testrunner
-just bc -generate 250
-

--- a/testconfig/scripts/wait_for_container.sh
+++ b/testconfig/scripts/wait_for_container.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-while [ "`docker inspect -f {{.State.Status}} $1`" != "running" ]; do
-     sleep 2;
-done
-
-docker exec bitcoin bitcoin-cli --rpcport=18443 --rpcuser=$BITCOIND_USER --rpcpassword=$BITCOIND_PASS createwallet ddk
-docker exec bitcoin bitcoin-cli --rpcport=18443 --rpcuser=$BITCOIND_USER --rpcpassword=$BITCOIND_PASS --rpcwallet=ddk -generate 101

--- a/testconfig/scripts/wait_for_electrs.sh
+++ b/testconfig/scripts/wait_for_electrs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-until $(curl --output /dev/null --silent --fail http://localhost:30000/blocks/tip/height); do
-    printf 'waiting for electrs to start'
-    docker exec bitcoin bitcoin-cli --rpcport=18443 --rpcuser=$BITCOIND_USER --rpcpassword=$BITCOIND_PASS -rpcwallet=$RPC_WALLET getblockcount
-    docker exec bitcoin bitcoin-cli --rpcport=18443 --rpcuser=$BITCOIND_USER --rpcpassword=$BITCOIND_PASS -rpcwallet=$RPC_WALLET -generate 1
-    sleep 5
-done

--- a/testenv/Cargo.toml
+++ b/testenv/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ddk-testenv"
+description = "Managed regtest backends for the dlcdevkit test suites."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+# Test-only helper crate. Never goes to crates.io; `ddk` and `ddk-manager`
+# depend on it through a path-only dev-dependency, which cargo strips when
+# packaging them.
+publish = false
+
+[features]
+default = []
+# In-process nostr relay, for the `nostr` transport tests.
+nostr = ["dep:nostr-relay-builder"]
+# Embedded PostgreSQL server, for the `postgres` storage tests.
+postgres = ["dep:postgresql_embedded"]
+
+[dependencies]
+bitcoin = { workspace = true, features = ["std"] }
+bitcoincore-rpc = { workspace = true }
+bitcoind = { workspace = true }
+electrsd = { workspace = true }
+libc = "0.2"
+
+nostr-relay-builder = { version = "0.44.1", optional = true }
+# Pinned to 0.19: 0.20+ raise the MSRV to 1.94, above this workspace's toolchain.
+postgresql_embedded = { version = "0.19.0", optional = true }

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -1,0 +1,266 @@
+//! Managed regtest backends for the DDK test suites.
+//!
+//! Every integration test used to point at a docker-compose stack over fixed
+//! ports (`18443` for bitcoind, `30000` for electrs) and read its connection
+//! details out of the environment. This crate replaces that: each test binary
+//! launches its own bitcoind and electrs on ephemeral ports, so `cargo test`
+//! needs nothing running beforehand.
+//!
+//! There are two ways to get backends, and the choice matters:
+//!
+//! [`env`] returns one bitcoind/electrs pair per test binary, shared by every
+//! test in it. Cheap, and fine for tests that only need somewhere to put coins.
+//!
+//! ```no_run
+//! let env = ddk_testenv::env();
+//! env.generate_blocks(5);
+//! let esplora = env.esplora_host();
+//! ```
+//!
+//! [`TestEnv::new`] returns a private pair, torn down when dropped. Tests that
+//! assert on contract state as blocks advance need this: libtest runs tests
+//! concurrently, and on a shared chain the blocks a sibling test mines can push
+//! a contract past a locktime before the assertion runs.
+//!
+//! ```no_run
+//! let env = ddk_testenv::TestEnv::new();
+//! let esplora = env.esplora_host();
+//! ```
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
+
+use bitcoin::{Address, Amount, Txid};
+use bitcoincore_rpc::{jsonrpc, Client, RpcApi};
+
+pub use bitcoincore_rpc;
+pub use bitcoind;
+pub use electrsd;
+
+#[cfg(feature = "nostr")]
+pub mod nostr;
+#[cfg(feature = "postgres")]
+pub mod postgres;
+
+/// Blocks mined during boot, so coinbase outputs are spendable immediately.
+const MATURITY_BLOCKS: u64 = 101;
+
+/// Read timeout for the test RPC clients.
+///
+/// Well above jsonrpc's 15s default. Several tests mine a hundred blocks in a
+/// single `generatetoaddress` call, and a dozen of them run at once, so a
+/// request can sit behind a lot of work before the node answers it.
+const RPC_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// A regtest bitcoind paired with an electrs serving the esplora HTTP API.
+///
+/// The two child processes are owned by [`Mutex`]es purely so [`shutdown`] can
+/// drop them from the process-exit hook; nothing else needs the interior
+/// mutability.
+///
+/// [`shutdown`]: TestEnv::shutdown
+pub struct TestEnv {
+    bitcoind: Mutex<Option<bitcoind::BitcoinD>>,
+    electrsd: Mutex<Option<electrsd::ElectrsD>>,
+    esplora_host: String,
+    rpc_url: String,
+    rpc_user: String,
+    rpc_password: String,
+    mine_address: Address,
+}
+
+static ENV: OnceLock<TestEnv> = OnceLock::new();
+
+/// Returns backends shared by every test in this binary, booting them on first
+/// call.
+///
+/// Suitable for test binaries holding a handful of tests that do not care what
+/// else is happening on the chain. Tests that assert on contract state as
+/// blocks advance need [`TestEnv::new`] instead: blocks another test mines are
+/// visible to all of them, which can drive a contract past a locktime early.
+pub fn env() -> &'static TestEnv {
+    ENV.get_or_init(|| {
+        // libtest exits the process via `std::process::exit`, which never runs
+        // destructors for statics. Without this hook the bitcoind and electrs
+        // children outlive the test binary and are left behind as orphans.
+        unsafe { libc::atexit(shutdown_at_exit) };
+        TestEnv::boot()
+    })
+}
+
+extern "C" fn shutdown_at_exit() {
+    if let Some(env) = ENV.get() {
+        env.shutdown();
+    }
+}
+
+/// Locks through poisoning: a panicking test must not prevent process cleanup.
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Builds an RPC client by hand rather than through [`Client::new`], so the
+/// transport gets [`RPC_TIMEOUT`] instead of jsonrpc's default.
+fn rpc_client(url: &str, user: &str, password: &str) -> Client {
+    let transport = jsonrpc::simple_http::Builder::new()
+        .url(url)
+        .expect("bitcoind RPC url is malformed")
+        .auth(user.to_string(), Some(password.to_string()))
+        .timeout(RPC_TIMEOUT)
+        .build();
+    Client::from_jsonrpc(jsonrpc::Client::with_transport(transport))
+}
+
+impl TestEnv {
+    /// Starts backends used by nothing else, torn down when the value is
+    /// dropped.
+    ///
+    /// Costs a few seconds, which buys a private chain: a test holding its own
+    /// environment cannot be perturbed by blocks other tests mine.
+    pub fn new() -> TestEnv {
+        TestEnv::boot()
+    }
+
+    fn boot() -> TestEnv {
+        let mut conf = bitcoind::Conf::default();
+        conf.args.push("-txindex=1");
+        conf.args.push("-addresstype=bech32");
+        conf.args.push("-fallbackfee=0.0002");
+        // libtest runs every test in a binary concurrently and they all share
+        // this node. The defaults (4 threads, a 16-deep queue) drop requests
+        // under that load, surfacing as `WouldBlock` transport errors.
+        conf.args.push("-rpcthreads=32");
+        conf.args.push("-rpcworkqueue=1024");
+        conf.wallet = Some("ddk".to_string());
+        let bitcoind = bitcoind::BitcoinD::with_conf(
+            bitcoind::exe_path().expect("no bitcoind executable available"),
+            &conf,
+        )
+        .expect("failed to start bitcoind");
+
+        let cookie = bitcoind
+            .params
+            .get_cookie_values()
+            .expect("failed to read the bitcoind cookie file")
+            .expect("bitcoind cookie file was empty");
+        let rpc_url = format!("http://{}/wallet/ddk", bitcoind.params.rpc_socket);
+        let rpc = rpc_client(&rpc_url, &cookie.user, &cookie.password);
+
+        let mine_address = rpc
+            .get_new_address(None, None)
+            .expect("RPC error")
+            .assume_checked();
+        rpc.generate_to_address(MATURITY_BLOCKS, &mine_address)
+            .expect("RPC error");
+
+        // electrs is started after the chain exists so its initial sync covers
+        // the mature coinbases in one pass.
+        let mut electrs_conf = electrsd::Conf::default();
+        electrs_conf.http_enabled = true;
+        electrs_conf.network = "regtest";
+        let electrsd = electrsd::ElectrsD::with_conf(
+            electrsd::exe_path().expect("no electrs executable available"),
+            &bitcoind,
+            &electrs_conf,
+        )
+        .expect("failed to start electrs");
+
+        // `esplora_url` is the bind address electrs was given (`0.0.0.0:port`),
+        // which is not a valid address to connect to.
+        let esplora_host = format!(
+            "http://{}",
+            electrsd
+                .esplora_url
+                .as_ref()
+                .expect("electrs was started with http_enabled")
+                .replace("0.0.0.0", "127.0.0.1")
+        );
+
+        TestEnv {
+            bitcoind: Mutex::new(Some(bitcoind)),
+            electrsd: Mutex::new(Some(electrsd)),
+            esplora_host,
+            rpc_url,
+            rpc_user: cookie.user,
+            rpc_password: cookie.password,
+            mine_address,
+        }
+    }
+
+    /// Base URL of the esplora HTTP API backed by this environment's chain.
+    pub fn esplora_host(&self) -> &str {
+        &self.esplora_host
+    }
+
+    /// A fresh RPC client bound to bitcoind's `ddk` wallet.
+    pub fn rpc(&self) -> Client {
+        rpc_client(&self.rpc_url, &self.rpc_user, &self.rpc_password)
+    }
+
+    /// Mines `count` blocks and returns once electrs has indexed the new tip.
+    ///
+    /// Waiting on the indexer is what makes the fixed sleeps the old suite used
+    /// unnecessary: when this returns, a wallet syncing against esplora will
+    /// see the blocks.
+    pub fn generate_blocks(&self, count: u64) {
+        let rpc = self.rpc();
+        let target = rpc.get_block_count().expect("RPC error") + count;
+        rpc.generate_to_address(count, &self.mine_address)
+            .expect("RPC error");
+        self.wait_for_height(target);
+    }
+
+    /// Blocks until electrs has indexed up to `height`.
+    pub fn wait_for_height(&self, height: u64) {
+        let guard = lock(&self.electrsd);
+        let electrsd = guard.as_ref().expect("electrs was shut down");
+        let _ = electrsd.trigger();
+        electrsd.wait_height(height as usize);
+    }
+
+    /// Blocks until electrs has indexed `txid` and its output scripts.
+    pub fn wait_for_tx(&self, txid: &Txid) {
+        let guard = lock(&self.electrsd);
+        let electrsd = guard.as_ref().expect("electrs was shut down");
+        let _ = electrsd.trigger();
+        electrsd.wait_tx(txid);
+    }
+
+    /// Sends `amount` to `address` from bitcoind's wallet, without confirming it.
+    pub fn send_to_address(&self, address: &Address, amount: Amount) -> Txid {
+        self.rpc()
+            .send_to_address(address, amount, None, None, None, None, None, None)
+            .expect("RPC error")
+    }
+
+    /// Sends `amount` to `address` and confirms it, leaving the funds spendable.
+    pub fn fund_address(&self, address: &Address, amount: Amount) -> Txid {
+        let txid = self.send_to_address(address, amount);
+        self.generate_blocks(1);
+        txid
+    }
+
+    /// Terminates both child processes. Idempotent.
+    fn shutdown(&self) {
+        // electrs first: it polls bitcoind and logs noisily if the daemon
+        // disappears from under it.
+        lock(&self.electrsd).take();
+        lock(&self.bitcoind).take();
+    }
+}
+
+impl Default for TestEnv {
+    fn default() -> Self {
+        TestEnv::new()
+    }
+}
+
+/// Cleans up environments created with [`TestEnv::new`]. The shared one from
+/// [`env`] is a static and never dropped; the process-exit hook covers it.
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}

--- a/testenv/src/nostr.rs
+++ b/testenv/src/nostr.rs
@@ -1,0 +1,25 @@
+//! An in-process nostr relay, replacing the `nostr-rs-relay` docker service.
+
+use nostr_relay_builder::prelude::*;
+
+/// A running relay. Shuts down when dropped, so tests must hold it for as long
+/// as they need it.
+pub struct TestRelay {
+    _relay: LocalRelay,
+    url: String,
+}
+
+impl TestRelay {
+    /// Starts a relay on an ephemeral port.
+    pub async fn start() -> TestRelay {
+        let relay = LocalRelay::new(RelayBuilder::default());
+        relay.run().await.expect("failed to start the local relay");
+        let url = relay.url().await.to_string();
+        TestRelay { _relay: relay, url }
+    }
+
+    /// The `ws://` URL to connect to.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}

--- a/testenv/src/postgres.rs
+++ b/testenv/src/postgres.rs
@@ -1,0 +1,49 @@
+//! An embedded PostgreSQL server, replacing the `postgres` docker service.
+//!
+//! The server binaries are downloaded on first use and cached under
+//! `~/.theseus/postgresql`; subsequent runs start from that cache.
+
+use postgresql_embedded::{PostgreSQL, Settings};
+
+/// A running PostgreSQL server with one database created.
+///
+/// Stops the server and removes its data directory when dropped, so tests must
+/// hold it for as long as they need it.
+pub struct TestPostgres {
+    _server: PostgreSQL,
+    url: String,
+}
+
+impl TestPostgres {
+    /// Starts a server on an ephemeral port and creates `database`.
+    pub async fn start(database: &str) -> TestPostgres {
+        let settings = Settings {
+            temporary: true,
+            ..Default::default()
+        };
+        let mut server = PostgreSQL::new(settings);
+        server
+            .setup()
+            .await
+            .expect("failed to install the embedded postgres");
+        server
+            .start()
+            .await
+            .expect("failed to start the embedded postgres");
+        server
+            .create_database(database)
+            .await
+            .expect("failed to create the test database");
+
+        let url = server.settings().url(database);
+        TestPostgres {
+            _server: server,
+            url,
+        }
+    }
+
+    /// The `postgresql://` connection URL for the created database.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}


### PR DESCRIPTION
# Run the test suites against managed regtest backends instead of docker compose

`cargo test` now needs nothing running beforehand. Each test binary starts and
tears down its own bitcoind, electrs (serving the esplora HTTP API), PostgreSQL
server, and nostr relay on ephemeral ports.

Before this, every integration test read its connection details out of the
environment (`BITCOIND_HOST`, `ESPLORA_HOST`, `DATABASE_URL`, ...) and expected
the docker-compose stack to already be up on fixed ports. CI reproduced that with
`docker compose up -d` plus a pair of polling scripts in front of every test job.

## What replaces what

| docker-compose service | replacement |
|---|---|
| `bitcoin` + `electrs` | [`bitcoind`](https://crates.io/crates/bitcoind) 0.41 + [`electrsd`](https://crates.io/crates/electrsd) 0.41 (`esplora_a33e97e1`) |
| `postgres` | [`postgresql_embedded`](https://crates.io/crates/postgresql_embedded) 0.19 |
| `nostr-relay` | [`nostr-relay-builder`](https://crates.io/crates/nostr-relay-builder) 0.44 (in-process) |

`docker-compose.yaml` stays: it is still how you run a `ddk-node` locally
(`just deps`). It is simply no longer involved in testing.

## The new `testenv` crate

`ddk-testenv` is a workspace member with `publish = false`, pulled in by `ddk`
and `ddk-manager` as a path-only dev-dependency. Cargo strips such dependencies
when packaging, so releases are unaffected — verified with `cargo package`.

It offers two ways to get backends, and the distinction matters:

- `ddk_testenv::env()` — one bitcoind/electrs pair per test binary, shared by
  every test in it. Cheap, and fine for tests that just need somewhere to put
  coins.
- `TestEnv::new()` — a private pair, torn down when dropped. Tests that assert on
  contract state as blocks advance need this. libtest runs tests concurrently,
  and on a shared chain the blocks a sibling test mines can push a contract past
  a locktime before the assertion runs. The manager execution and splice tests
  use it, which is why `init_clients` and `create_and_fund_wallet` gained an
  `&TestEnv` parameter.

Mining helpers now block on the indexer (`ElectrsD::wait_height`) rather than
sleeping. That replaces the `sleep(Duration::from_secs(5))` polling loops the old
helpers used, and is where most of the wall-clock saving comes from.

## Details worth reviewing

**Process cleanup.** libtest exits via `std::process::exit`, which never runs
destructors for statics, so the shared environment's child processes would
outlive the test binary as orphans. `env()` registers a `libc::atexit` hook;
per-test environments clean up through `Drop`. A full 50-test run leaves zero
stray processes.

**RPC timeouts.** Several tests mine 101 blocks in a single `generatetoaddress`,
and a dozen of them run at once, so requests sit behind a lot of work. The test
RPC clients are built by hand with a 300s transport timeout instead of jsonrpc's
15s default, and the node runs with `-rpcthreads=32 -rpcworkqueue=1024`.

**`NB_CONFIRMATIONS=6` is load-bearing.** The `cooperative_close` tests fail at
the default of 3. This is pre-existing — verified against the current `master`
code pointed at an external node — and CI already sets it. It is now documented
in the README so local runs match.

**CI cache.** The matrix jobs now restore `target/debug/build` alongside
`target/debug/deps`, because the bitcoind and electrs executables live in the
build scripts' `OUT_DIR` and the test binaries resolve them through a path baked
in at compile time.

## Known constraints

- The macOS electrs binary published by `electrsd` is x86_64, so Apple Silicon
  needs Rosetta. Linux CI is unaffected.
- `postgresql_embedded` is pinned to 0.19 because 0.20+ raise the MSRV to 1.94,
  above this workspace's toolchain. Bumping it later means bumping the toolchain.
- Postgres binaries are downloaded on first use and cached under
  `~/.theseus/postgresql`; CI caches that directory.

## Verification

Run with docker down and no connection environment variables set:

| suite | result |
|---|---|
| `cargo test --all-features` | 259 passed, 0 failed |
| `manager_execution_tests --ignored` | 50/50 |
| `stateless_execution --ignored` | 29/29 |
| `splice_execution_tests --ignored` | 1/1 |
| orphaned processes afterward | 0 |

`cargo clippy -- -D warnings` and `cargo fmt --check` are clean.

## Follow-up

The `stateless-dlc-creation` branch adds `ddk/tests/stateless_utils.rs`, which
still reads `ESPLORA_HOST` / `BITCOIND_*`. It needs the same treatment when the
two branches meet — `ChainContext::new` should take its esplora host and RPC
client from `ddk_testenv::env()`. Its 29 tests pass on the shared environment, so
no per-test isolation is needed there.
