### PR TITLE
fix(oracle): read and write oracle messages as standalone TLV records

### DIFF
--- a/ddk/src/oracle/nostr.rs
+++ b/ddk/src/oracle/nostr.rs
@@ -8,8 +8,7 @@ use crate::logger::{log_debug, log_error, log_info, log_warn, WriteLog};
 use bitcoin::XOnlyPublicKey;
 use ddk_manager::error::Error as ManagerError;
 use ddk_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
-use lightning::io::Cursor;
-use lightning::util::ser::Readable;
+use ddk_messages::TlvRecord;
 use nostr_database::MemoryDatabase;
 use nostr_database::NostrDatabase;
 use nostr_rs::event::EventId;
@@ -268,13 +267,18 @@ impl ddk_manager::Oracle for NostrOracle {
     }
 }
 
-fn decode_base64<T: Readable>(content: &str) -> Result<T, OracleError> {
+/// Decodes an oracle message from the base64 content of a nostr event.
+///
+/// Events carry the message in its standalone TLV form. Events published before that
+/// was settled carry the TLV body alone, and a relay keeps them forever, so both forms
+/// are accepted here.
+fn decode_base64<T: TlvRecord>(content: &str) -> Result<T, OracleError> {
     use base64::Engine as _;
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(content)
         .map_err(|_| OracleError::Custom("Failed to decode base64.".to_string()))?;
-    let mut cursor = Cursor::new(bytes);
-    T::read(&mut cursor).map_err(|_| OracleError::Custom("Failed to read event.".to_string()))
+    T::from_tlv_bytes_or_legacy(&bytes)
+        .map_err(|_| OracleError::Custom("Failed to read event.".to_string()))
 }
 
 #[cfg(test)]
@@ -283,6 +287,32 @@ mod tests {
     use nostr_rs::event::Event;
 
     use super::*;
+
+    const REAL_ANNOUNCEMENT_HEX: &str = "fdd824fd012a73740e61118e5d1c2c223c986b859a42c2cca56cb621d13ff8880ea856caf24aa29bc36a1e0d5c471b6a2baa68f98a413362c4e6a97f13c04b186395e9e0d8fcc3d07289c2ade25405c1c421b38c9322cd73fb2c89f42ce0730a35fae1f8875dfdd822c60001529fadc9958e1e1cf8ea29f05a25d67e04a0c21dcbfcb99b8b24d32f274795eb68e81101fdd8064e0004086e6f742d70616964067265706169641d6c6971756964617465642d62792d6d617475726174696f6e2d646174651d6c6971756964617465642d62792d70726963652d7468726573686f6c644d6c6f616e2d6d6174757265642d38313233313935633631653439376631323465623764336266626531323232613530326233306162343139363766306466323036306133656533366635623063";
+
+    /// Announcements published to a relay before this crate wrote the TLV form
+    /// carry the bare body. A relay keeps them forever, so a client upgrading to
+    /// this version must still be able to read what is already out there.
+    #[test]
+    fn legacy_body_form_nostr_events_still_decode() {
+        use base64::Engine as _;
+        use lightning::util::ser::Writeable;
+
+        let announcement = OracleAnnouncement::from_tlv_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+
+        let legacy = base64::engine::general_purpose::STANDARD.encode(announcement.encode());
+        let current = base64::engine::general_purpose::STANDARD.encode(announcement.to_tlv_bytes());
+        assert_ne!(legacy, current, "the two forms must actually differ");
+
+        assert_eq!(
+            decode_base64::<OracleAnnouncement>(&legacy).unwrap(),
+            announcement
+        );
+        assert_eq!(
+            decode_base64::<OracleAnnouncement>(&current).unwrap(),
+            announcement
+        );
+    }
 
     async fn test_send_announcement(
         key: nostr_rs::key::Keys,

--- a/ddk/src/util/ser.rs
+++ b/ddk/src/util/ser.rs
@@ -201,3 +201,96 @@ pub fn message_variant_name(message: &Message) -> String {
 
     str.to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every contract state, serialized by an earlier release and checked in.
+    ///
+    /// Each embeds at least one [`ddk_messages::oracle_msgs::OracleAnnouncement`],
+    /// which is what makes these the evidence that matters for oracle serialization.
+    const FIXTURES: &[(&str, &[u8])] = &[
+        (
+            "Offered",
+            include_bytes!("../../../testconfig/contract_binaries/Offered"),
+        ),
+        (
+            "Accepted",
+            include_bytes!("../../../testconfig/contract_binaries/Accepted"),
+        ),
+        (
+            "Signed",
+            include_bytes!("../../../testconfig/contract_binaries/Signed"),
+        ),
+        (
+            "Confirmed",
+            include_bytes!("../../../testconfig/contract_binaries/Confirmed"),
+        ),
+        (
+            "PreClosed",
+            include_bytes!("../../../testconfig/contract_binaries/PreClosed"),
+        ),
+        (
+            "Closed",
+            include_bytes!("../../../testconfig/contract_binaries/Closed"),
+        ),
+    ];
+
+    /// Stored contracts must survive a read and a write with every byte intact.
+    ///
+    /// A contract carries its oracle announcements in the embedded body form, so any
+    /// change to how those are written shows up here as a diff against bytes an
+    /// earlier release produced. This is what a stored `BYTEA` column would have to
+    /// be migrated for; while it passes, there is nothing to migrate.
+    #[test]
+    fn stored_contracts_round_trip_byte_for_byte() {
+        for (state, stored) in FIXTURES {
+            let contract = deserialize_contract(&stored.to_vec())
+                .unwrap_or_else(|e| panic!("{state} contract failed to deserialize: {e:?}"));
+
+            let reserialized = serialize_contract(&contract)
+                .unwrap_or_else(|e| panic!("{state} contract failed to serialize: {e:?}"));
+
+            assert_eq!(
+                reserialized,
+                stored.to_vec(),
+                "{state} contract did not round trip; the storage format changed"
+            );
+        }
+    }
+
+    /// The oldest offered contract we keep a fixture for still reads.
+    ///
+    /// Only `old/Offered` is asserted. The other fixtures under `old/` predate
+    /// unrelated changes to the contract structs and have not deserialized for
+    /// some time, which is a separate matter from how oracle messages are written.
+    #[test]
+    fn oldest_offered_contract_still_deserializes() {
+        let stored = include_bytes!("../../../testconfig/contract_binaries/old/Offered");
+        deserialize_contract(&stored.to_vec()).expect("oldest offered contract to deserialize");
+    }
+
+    /// The announcement inside a stored contract is the one the oracle signed.
+    ///
+    /// Reading it out and writing it back as a standalone TLV record must reproduce
+    /// the hex an oracle would serve, which is the round trip consumers were doing
+    /// by hand.
+    #[test]
+    fn announcement_inside_a_stored_contract_survives_as_a_standalone_record() {
+        use ddk_messages::TlvRecord;
+
+        let stored = include_bytes!("../../../testconfig/contract_binaries/Offered");
+        let Contract::Offered(offered) = deserialize_contract(&stored.to_vec()).unwrap() else {
+            panic!("fixture is not an offered contract");
+        };
+
+        let announcement = &offered.contract_info[0].oracle_announcements[0];
+        let tlv = announcement.to_tlv_bytes();
+
+        assert_eq!(
+            ddk_messages::oracle_msgs::OracleAnnouncement::from_tlv_bytes(&tlv).unwrap(),
+            *announcement
+        );
+    }
+}

--- a/dlc-messages/src/lib.rs
+++ b/dlc-messages/src/lib.rs
@@ -18,6 +18,8 @@ extern crate secp256k1_zkp;
 pub mod ser_macros;
 pub mod ser_impls;
 
+pub use ser_impls::{TlvRecord, TlvType};
+
 #[cfg(any(test, feature = "use-serde"))]
 extern crate serde;
 

--- a/dlc-messages/src/oracle_msgs.rs
+++ b/dlc-messages/src/oracle_msgs.rs
@@ -2,12 +2,11 @@
 
 use crate::ser_impls::{
     read_as_tlv, read_i32, read_schnorr_pubkey, read_schnorrsig, read_strings_u16, write_as_tlv,
-    write_i32, write_schnorr_pubkey, write_schnorrsig, write_strings_u16, BigSize,
+    write_i32, write_schnorr_pubkey, write_schnorrsig, write_strings_u16, TlvRecord,
 };
 use bitcoin::hashes::{Hash, HashEngine};
 use ddk_dlc::{Error, OracleInfo as DlcOracleInfo};
 use lightning::ln::msgs::DecodeError;
-use lightning::ln::wire::Type;
 use lightning::util::ser::{Readable, Writeable, Writer};
 use secp256k1_zkp::Verification;
 use secp256k1_zkp::{schnorr::Signature, Message, Secp256k1, XOnlyPublicKey};
@@ -16,6 +15,8 @@ use serde::{Deserialize, Serialize};
 
 /// The type of the announcement struct.
 pub const ANNOUNCEMENT_TYPE: u16 = 55332;
+/// The type of the oracle event struct.
+pub const ORACLE_EVENT_TYPE: u16 = 55330;
 /// The type of the attestation struct.
 pub const ATTESTATION_TYPE: u16 = 55400;
 
@@ -165,35 +166,17 @@ pub struct OracleAnnouncement {
     pub oracle_event: OracleEvent,
 }
 
-impl Type for OracleAnnouncement {
-    fn type_id(&self) -> u16 {
-        ANNOUNCEMENT_TYPE
-    }
-}
-
-/// TODO: this should be handled by the read/write macros. They do not append
-/// the tagged hash to the event. As well, [`crate::Message`]
-///
-/// It should end up being back to original:
-///
-/// self.event.write(&mut event_hex)?;
-///
-fn write_oracle_event(event: &OracleEvent) -> Result<Vec<u8>, lightning::io::Error> {
-    let mut event_hex = Vec::new();
-    BigSize(event.type_id() as u64).write(&mut event_hex)?;
-    BigSize(event.serialized_length() as u64).write(&mut event_hex)?;
-    event
-        .write(&mut event_hex)
-        .expect("Error writing oracle event");
-    Ok(event_hex)
-}
+impl_dlc_tlv_record!(OracleAnnouncement, ANNOUNCEMENT_TYPE);
 
 /// Returns the message to be signed for an oracle announcement.
 ///
 /// Follows the signing validation rules from the [DLC spec](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#signing-algorithm).
+///
+/// The event is hashed in its standalone TLV form, header included, which is what
+/// oracles in the wild sign over.
 pub fn tagged_announcement_msg(event: &OracleEvent) -> Message {
     let tag_hash = bitcoin::hashes::sha256::Hash::hash(ORACLE_ANNOUNCEMENT_TAG);
-    let event_hex = write_oracle_event(event).expect("Error writing oracle event");
+    let event_hex = event.to_tlv_bytes();
     let mut hash_engine = bitcoin::hashes::sha256::Hash::engine();
     hash_engine.input(&tag_hash[..]);
     hash_engine.input(&tag_hash[..]);
@@ -284,11 +267,7 @@ impl OracleEvent {
     }
 }
 
-impl Type for OracleEvent {
-    fn type_id(&self) -> u16 {
-        55330
-    }
-}
+impl_dlc_tlv_record!(OracleEvent, ORACLE_EVENT_TYPE);
 
 impl_dlc_writeable!(OracleEvent, {
     (oracle_nonces, {vec_u16_cb, write_schnorr_pubkey, read_schnorr_pubkey}),
@@ -440,11 +419,7 @@ impl OracleAttestation {
     }
 }
 
-impl Type for OracleAttestation {
-    fn type_id(&self) -> u16 {
-        ATTESTATION_TYPE
-    }
-}
+impl_dlc_tlv_record!(OracleAttestation, ATTESTATION_TYPE);
 
 impl_dlc_writeable!(OracleAttestation, {
     (event_id, string),
@@ -456,7 +431,9 @@ impl_dlc_writeable!(OracleAttestation, {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ser_impls::TlvType;
     use bitcoin::bip32::{ChildNumber, Xpriv};
+    use bitcoin::hex::FromHex;
     use bitcoin::Network;
     use secp256k1_zkp::rand::Fill;
     use secp256k1_zkp::SecretKey;
@@ -533,6 +510,210 @@ mod tests {
         let nonce_xpub = nonce_priv.x_only_public_key(SECP256K1).0;
 
         (nonce_priv, nonce_xpub)
+    }
+
+    /// A real announcement served by a production oracle, in the standalone hex form
+    /// its HTTP API returns.
+    const REAL_ANNOUNCEMENT_HEX: &str = "fdd824fd012a73740e61118e5d1c2c223c986b859a42c2cca56cb621d13ff8880ea856caf24aa29bc36a1e0d5c471b6a2baa68f98a413362c4e6a97f13c04b186395e9e0d8fcc3d07289c2ade25405c1c421b38c9322cd73fb2c89f42ce0730a35fae1f8875dfdd822c60001529fadc9958e1e1cf8ea29f05a25d67e04a0c21dcbfcb99b8b24d32f274795eb68e81101fdd8064e0004086e6f742d70616964067265706169641d6c6971756964617465642d62792d6d617475726174696f6e2d646174651d6c6971756964617465642d62792d70726963652d7468726573686f6c644d6c6f616e2d6d6174757265642d38313233313935633631653439376631323465623764336266626531323232613530326233306162343139363766306466323036306133656533366635623063";
+
+    /// The matching attestation from the same oracle.
+    const REAL_ATTESTATION_HEX: &str = "fdd868d04d6c6f616e2d6d6174757265642d39666235336365663365663134383863626230373532643036636263373738633237353532663963373666656634353436653637343038353935626532363832dde465c101a1aaa5a88c0d35d21744eb5352c62b7c7665d62d5f20c770ddfd8f00010c914fa0638767ee55ef16ea009f85548ac43c3d447b47c1ff22724fd0a48b159c9690d0cec7e7ae47a1ceb232b0a2c13404173b9f5e9dc16fe63d31c78c615100011d6c6971756964617465642d62792d6d617475726174696f6e2d64617465";
+
+    /// A numeric announcement, taken from node-dlc's own test vectors.
+    ///
+    /// This is the only fixture covering `digit_decomposition_event_descriptor`
+    /// (55306) in bytes another implementation produced. The enum fixtures all
+    /// take the 55302 branch, so without this the descriptor read path is
+    /// exercised only against announcements this crate wrote itself.
+    const NODE_DLC_NUMERIC_ANNOUNCEMENT_HEX: &str = "fdd824fd02ab1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937eb8b005b07acf849ad2cec22107331dedbf5a607654fad4eafe39c278e27dde68fdd822fd02450011f9313f1edd903fab297d5350006b669506eb0ffda0bb58319b4df89ac24e14fd15f9791dc78d1596b06f4969bdb37d9e394dc9fedaa18d694027fa32b5ea2a5e60080c58e13727367c3a4ce1ad65dfb3c7e3ca1ea912b0299f6e383bab2875058aa96a1c74633130af6fbd008788de6ac9db76da4ecc7303383cc1a49f525316413850f7e3ac385019d560e84c5b3a3e9ae6c83f59fe4286ddfd23ea46d7ae04610a175cd28a9bf5f574e245c3dfe230dc4b0adf4daaea96780e594f6464f676505f4b74cfe3ffc33415a23de795bf939ce64c0c02033bbfc6c9ff26fb478943a1ece775f38f5db067ca4b2a9168b40792398def9164bfe5c46838472dc3c162af16c811b7a116e9417d5bccb9e5b8a5d7d26095aba993696188c3f85a02f7ab8d12ada171c352785eb63417228c7e248909fc2d673e1bb453140bf8bf429375819afb5e9556663b76ff09c2a7ba9779855ffddc6d360cb459cf8c42a2b949d0de19fe96163d336fd66a4ce2f1791110e679572a20036ffae50204ef520c01058ff4bef28218d1c0e362ee3694ad8b2ae83a51c86c4bc1630ed6202a158810096726f809fc828fafdcf053496affdf887ae8c54b6ca4323ccecf6a51121c4f0c60e790536dab41b221db1c6b35065dc19a9d31cf75901aa35eefecbb6fefd07296cda13cb34ce3b58eba20a0eb8f9614994ec7fee3cc290e30e6b1e3211ae1f3a85b6de6abdbb77d6d9ed33a1cee3bd5cd93a71f12c9c45e385d744ad0e7286660305100fdd80a11000200076274632f75736400000000001109425443205072696365";
+
+    /// An enum announcement, also from node-dlc's test vectors.
+    const NODE_DLC_ENUM_ANNOUNCEMENT_HEX: &str = "fdd824a4fab22628f6e2602e1671c286a2f63a9246794008627a1749639217f4214cb4a9494c93d1a852221080f44f697adb4355df59eb339f6ba0f9b01ba661a8b108d4da078bbb1d34e7729e38e2ae34236e776da121af442626fa31e31ae55a279a0bfdd8224000013cfba011378411b20a5ab773cb95daab93e9bcd1e4cce44986a7dda84e01841b00000000fdd8061000020664756d6d79310664756d6d79320564756d6d79";
+
+    /// The record types are consensus. Pinning them here means a rename or a
+    /// refactor that changes one is a test failure rather than a wire break
+    /// discovered by a peer.
+    #[test]
+    fn record_types_match_the_specification() {
+        assert_eq!(<OracleAnnouncement as TlvType>::TYPE_ID, 55332);
+        assert_eq!(<OracleEvent as TlvType>::TYPE_ID, 55330);
+        assert_eq!(<OracleAttestation as TlvType>::TYPE_ID, 55400);
+    }
+
+    /// The JSON shape is a separate wire format with its own consumers: oracle
+    /// HTTP APIs exchange announcements and attestations this way, and it is what
+    /// `KormirOracleClient` deserializes. Nothing here changed it, and this pins
+    /// that so a future serialization change cannot break it unnoticed.
+    #[cfg(feature = "use-serde")]
+    #[test]
+    fn json_representation_is_unchanged() {
+        let announcement = OracleAnnouncement::from_tlv_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+        let value = serde_json::to_value(&announcement).unwrap();
+
+        // camelCase keys, hex-encoded keys and signatures.
+        assert!(value.get("announcementSignature").is_some());
+        assert!(value.get("oraclePublicKey").is_some());
+        let event = value.get("oracleEvent").expect("oracleEvent");
+        assert!(event.get("oracleNonces").is_some());
+        assert!(event.get("eventMaturityEpoch").is_some());
+        assert!(event.get("eventDescriptor").is_some());
+        assert_eq!(
+            event.get("eventId").and_then(|v| v.as_str()),
+            Some("loan-matured-8123195c61e497f124eb7d3bfbe1222a502b30ab41967f0df2060a3ee36f5b0c")
+        );
+
+        let back: OracleAnnouncement = serde_json::from_value(value).unwrap();
+        assert_eq!(back, announcement);
+        assert_eq!(back.to_tlv_hex(), REAL_ANNOUNCEMENT_HEX);
+
+        let attestation = OracleAttestation::from_tlv_hex(REAL_ATTESTATION_HEX).unwrap();
+        let back: OracleAttestation =
+            serde_json::from_value(serde_json::to_value(&attestation).unwrap()).unwrap();
+        assert_eq!(back, attestation);
+        assert_eq!(back.to_tlv_hex(), REAL_ATTESTATION_HEX);
+    }
+
+    #[test]
+    fn node_dlc_announcements_round_trip() {
+        for hex in [
+            NODE_DLC_NUMERIC_ANNOUNCEMENT_HEX,
+            NODE_DLC_ENUM_ANNOUNCEMENT_HEX,
+        ] {
+            let announcement =
+                OracleAnnouncement::from_tlv_hex(hex).expect("a node-dlc announcement to parse");
+            assert_eq!(announcement.to_tlv_hex(), hex);
+        }
+    }
+
+    #[test]
+    fn node_dlc_numeric_announcement_reads_its_digit_decomposition_descriptor() {
+        let announcement = OracleAnnouncement::from_tlv_hex(NODE_DLC_NUMERIC_ANNOUNCEMENT_HEX)
+            .expect("a node-dlc numeric announcement to parse");
+
+        let EventDescriptor::DigitDecompositionEvent(descriptor) =
+            &announcement.oracle_event.event_descriptor
+        else {
+            panic!("expected a digit decomposition descriptor");
+        };
+
+        assert_eq!(descriptor.base, 2);
+        assert!(!descriptor.is_signed);
+        assert_eq!(descriptor.unit, "btc/usd");
+        assert_eq!(descriptor.precision, 0);
+        assert_eq!(descriptor.nb_digits, 17);
+        assert_eq!(announcement.oracle_event.event_id, "BTC Price");
+        assert_eq!(announcement.oracle_event.oracle_nonces.len(), 17);
+
+        // One nonce per digit, which is what the announcement claims and what a
+        // contract built from it will rely on.
+        announcement.oracle_event.validate().expect("a valid event");
+    }
+
+    #[test]
+    fn real_oracle_announcement_reads_from_its_standalone_hex() {
+        let announcement = OracleAnnouncement::from_tlv_hex(REAL_ANNOUNCEMENT_HEX)
+            .expect("a production announcement to parse");
+
+        assert_eq!(
+            announcement.oracle_event.event_id,
+            "loan-matured-8123195c61e497f124eb7d3bfbe1222a502b30ab41967f0df2060a3ee36f5b0c"
+        );
+        announcement
+            .validate(SECP256K1)
+            .expect("a production announcement to carry a valid signature");
+
+        // The bytes we write back must be the exact bytes the oracle signed over.
+        assert_eq!(announcement.to_tlv_hex(), REAL_ANNOUNCEMENT_HEX);
+    }
+
+    #[test]
+    fn real_oracle_attestation_reads_from_its_standalone_hex() {
+        let attestation = OracleAttestation::from_tlv_hex(REAL_ATTESTATION_HEX)
+            .expect("a production attestation to parse");
+
+        assert_eq!(attestation.outcomes, vec!["liquidated-by-maturation-date"]);
+        assert_eq!(attestation.signatures.len(), 1);
+        assert_eq!(attestation.to_tlv_hex(), REAL_ATTESTATION_HEX);
+    }
+
+    #[test]
+    fn tlv_form_and_body_form_are_distinct_and_neither_reads_as_the_other() {
+        let announcement = OracleAnnouncement::from_tlv_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+        let tlv = announcement.to_tlv_bytes();
+        let body = announcement.encode();
+
+        // The TLV form is the body behind a type and length header, and each reader
+        // accepts only its own form. This is the mismatch that made callers strip
+        // the header by hand; `TlvRecord` is what they should reach for instead.
+        let mut header = Vec::new();
+        crate::ser_impls::BigSize(ANNOUNCEMENT_TYPE as u64)
+            .write(&mut header)
+            .unwrap();
+        crate::ser_impls::BigSize(body.len() as u64)
+            .write(&mut header)
+            .unwrap();
+        assert_eq!(tlv, [header.as_slice(), body.as_slice()].concat());
+        assert!(OracleAnnouncement::read(&mut lightning::io::Cursor::new(&tlv)).is_err());
+        assert!(OracleAnnouncement::from_tlv_bytes(&body).is_err());
+    }
+
+    #[test]
+    fn legacy_body_bytes_still_read_through_the_compatibility_reader() {
+        let announcement = OracleAnnouncement::from_tlv_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+        let attestation = OracleAttestation::from_tlv_hex(REAL_ATTESTATION_HEX).unwrap();
+
+        // Both the stored form written before the standalone form was settled...
+        assert_eq!(
+            OracleAnnouncement::from_tlv_bytes_or_legacy(&announcement.encode()).unwrap(),
+            announcement
+        );
+        assert_eq!(
+            OracleAttestation::from_tlv_bytes_or_legacy(&attestation.encode()).unwrap(),
+            attestation
+        );
+
+        // ...and the current one are readable, so a store holding a mix of the two
+        // migrates without anyone having to know which row is which.
+        assert_eq!(
+            OracleAnnouncement::from_tlv_bytes_or_legacy(&announcement.to_tlv_bytes()).unwrap(),
+            announcement
+        );
+        assert_eq!(
+            OracleAttestation::from_tlv_bytes_or_legacy(&attestation.to_tlv_bytes()).unwrap(),
+            attestation
+        );
+    }
+
+    #[test]
+    fn a_record_of_the_wrong_type_is_rejected_rather_than_misread() {
+        let announcement_bytes = Vec::<u8>::from_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+        let attestation_bytes = Vec::<u8>::from_hex(REAL_ATTESTATION_HEX).unwrap();
+
+        assert!(OracleAttestation::from_tlv_bytes(&announcement_bytes).is_err());
+        assert!(OracleAnnouncement::from_tlv_bytes(&attestation_bytes).is_err());
+
+        // The lenient reader must not paper over a type mismatch by falling through
+        // to the body reader and decoding the header as message content.
+        assert!(OracleAttestation::from_tlv_bytes_or_legacy(&announcement_bytes).is_err());
+    }
+
+    #[test]
+    fn truncated_and_overlong_records_are_rejected() {
+        let bytes = Vec::<u8>::from_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+
+        let mut truncated = bytes.clone();
+        truncated.pop();
+        assert!(OracleAnnouncement::from_tlv_bytes(&truncated).is_err());
+
+        let mut trailing = bytes.clone();
+        trailing.push(0x00);
+        assert!(OracleAnnouncement::from_tlv_bytes(&trailing).is_err());
+
+        // A header that claims a shorter body than the record actually holds must
+        // fail, not silently return a value and leave the reader mid-record.
+        let mut short_length = bytes.clone();
+        short_length[4] = 0x2a - 1;
+        assert!(OracleAnnouncement::from_tlv_bytes(&short_length).is_err());
     }
 
     #[test]

--- a/dlc-messages/src/ser_impls.rs
+++ b/dlc-messages/src/ser_impls.rs
@@ -1,5 +1,6 @@
 //! Set of utility functions to help with serialization.
 
+use bitcoin::hex::{DisplayHex, FromHex};
 use bitcoin::Address;
 use bitcoin::Network;
 use bitcoin::SignedAmount;
@@ -593,7 +594,136 @@ pub fn read_signed_amount<R: ::lightning::io::Read>(
     Ok(SignedAmount::from_sat(signed_amount))
 }
 
+/// A type that is framed as a TLV record: its record type and body length, both as
+/// [`BigSize`], ahead of the body.
+///
+/// # Not the same as [`Type`]
+///
+/// [`Type`] marks a *wire message* — a `u16` type followed by the body, with no length,
+/// which is how the DLC protocol messages travel between peers. This trait marks a *TLV
+/// record*, which carries a length as well. The two framings are not interchangeable, so
+/// a type declares whichever one describes it. A type may hold both marks, but only when
+/// it genuinely appears in both framings.
+///
+/// # Why the constant
+///
+/// [`Type`] gives the record type through `&self`, so a reader holding only a byte stream
+/// has nothing to compare the type it reads against. This associated constant supplies it,
+/// which lets [`read_as_tlv`] reject a record whose type does not match the type being read
+/// instead of decoding it into nonsense.
+///
+/// Declare it with [`impl_dlc_tlv_record!`](crate::impl_dlc_tlv_record) rather than by hand;
+/// that macro also derives the [`Type`] impl from the same constant so the two cannot drift.
+pub trait TlvType {
+    /// The TLV record type of this message, as assigned by the DLC specification.
+    const TYPE_ID: u16;
+}
+
+/// A TLV record that also travels on its own, outside any containing message.
+///
+/// # The problem this solves
+///
+/// A type in this position has two jobs that pull in opposite directions. Nested inside
+/// another message, its [`Writeable`] impl must write the body *alone*, because the
+/// container adds the header through [`write_as_tlv`]; an impl that wrote its own header
+/// would double-wrap the field and invalidate every previously stored message. Travelling
+/// alone — an HTTP response, a nostr event, a `BYTEA` column, a hex string in an RPC — it
+/// needs the header, because nothing else is there to add it.
+///
+/// One [`Writeable`] impl cannot do both, so callers who reached for [`Readable::read`] on
+/// standalone bytes found it failed and hand-rolled the two [`BigSize`] reads to strip the
+/// header. This trait is the second entry point, so nobody writes those lines again.
+///
+/// `oracle_announcement` is the case in the DLC specification today. It is not obviously
+/// the last one, so this is a blanket impl: any type that declares [`TlvType`] and is
+/// readable and writeable gets the standalone form for free, with nothing to remember.
+///
+/// ```
+/// use ddk_messages::oracle_msgs::OracleAnnouncement;
+/// use ddk_messages::TlvRecord;
+///
+/// # fn example(hex_from_oracle: &str) -> Result<(), lightning::ln::msgs::DecodeError> {
+/// let announcement = OracleAnnouncement::from_tlv_hex(hex_from_oracle)?;
+/// let bytes_for_storage = announcement.to_tlv_bytes();
+/// # Ok(())
+/// # }
+/// ```
+pub trait TlvRecord: TlvType + Readable + Writeable {
+    /// Serializes the value as a TLV record, header included.
+    fn to_tlv_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.serialized_length() + 8);
+        BigSize(Self::TYPE_ID as u64)
+            .write(&mut bytes)
+            .expect("writing to a Vec cannot fail");
+        BigSize(self.serialized_length() as u64)
+            .write(&mut bytes)
+            .expect("writing to a Vec cannot fail");
+        self.write(&mut bytes)
+            .expect("writing to a Vec cannot fail");
+        bytes
+    }
+
+    /// Deserializes a TLV record produced by [`Self::to_tlv_bytes`].
+    ///
+    /// The record type and the declared length are both checked, and the record must use
+    /// up `bytes` exactly. Trailing bytes are an error rather than something to ignore,
+    /// because a record that does not account for its whole buffer was not understood.
+    fn from_tlv_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let mut cursor = lightning::io::Cursor::new(bytes);
+        let value = read_as_tlv(&mut cursor)?;
+        if (cursor.position() as usize) != bytes.len() {
+            return Err(DecodeError::InvalidValue);
+        }
+        Ok(value)
+    }
+
+    /// Serializes the value as a lowercase hex TLV record.
+    ///
+    /// This is the interchange format oracles use over HTTP and the one the DLC
+    /// specification's test vectors are written in.
+    fn to_tlv_hex(&self) -> String {
+        self.to_tlv_bytes().to_lower_hex_string()
+    }
+
+    /// Deserializes a hex TLV record produced by [`Self::to_tlv_hex`].
+    fn from_tlv_hex(hex: &str) -> Result<Self, DecodeError> {
+        let bytes = Vec::<u8>::from_hex(hex).map_err(|_| DecodeError::InvalidValue)?;
+        Self::from_tlv_bytes(&bytes)
+    }
+
+    /// Deserializes a TLV record, falling back to a bare body if no TLV header is present.
+    ///
+    /// Use this, and only this, to read bytes persisted before a type gained its standalone
+    /// form: a store written through [`Writeable::encode`] holds header-less bodies, one
+    /// written from a producer's own bytes holds full TLV records, and a store that has seen
+    /// both holds a mix.
+    ///
+    /// The fallback is sound only where a body cannot begin with this record's own type id
+    /// as a [`BigSize`] followed by a length that accounts for the buffer exactly. That
+    /// holds for the oracle messages, whose bodies open with a Schnorr signature or a string
+    /// length. Check it before relying on this for a new type.
+    ///
+    /// New writes should always go through [`Self::to_tlv_bytes`], leaving this needed only
+    /// until the last legacy row is migrated.
+    fn from_tlv_bytes_or_legacy(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if let Ok(value) = Self::from_tlv_bytes(bytes) {
+            return Ok(value);
+        }
+        let mut cursor = lightning::io::Cursor::new(bytes);
+        let value = Self::read(&mut cursor)?;
+        if (cursor.position() as usize) != bytes.len() {
+            return Err(DecodeError::InvalidValue);
+        }
+        Ok(value)
+    }
+}
+
+impl<T: TlvType + Readable + Writeable> TlvRecord for T {}
+
 /// Writes a [`lightning::util::ser::Writeable`] value to the given writer as a TLV.
+///
+/// The value is prefixed by its record type and by the length of its body, both as
+/// [`BigSize`]. [`read_as_tlv`] is the matching reader.
 pub fn write_as_tlv<T: Type + Writeable, W: Writer>(
     e: &T,
     writer: &mut W,
@@ -603,14 +733,33 @@ pub fn write_as_tlv<T: Type + Writeable, W: Writer>(
     e.write(writer)
 }
 
-/// Read a [`lightning::util::ser::Writeable`] value from the given reader as a TLV.
-pub fn read_as_tlv<T: Type + Readable, R: Read>(reader: &mut R) -> Result<T, DecodeError> {
-    // TODO(tibo): consider checking type here.
-    // This retrieves type as BigSize. Will be u16 once specs are updated.
-    let _: BigSize = Readable::read(reader)?;
-    // This retrieves the length, will be removed once oracle specs are updated.
-    let _: BigSize = Readable::read(reader)?;
-    Readable::read(reader)
+/// Reads a [`lightning::util::ser::Readable`] value from the given reader as a TLV.
+///
+/// Both halves of the TLV header are enforced: the record type must be [`TlvType::TYPE_ID`],
+/// and the body must consume exactly the number of bytes the header declares. Without those
+/// checks a truncated or mistyped record decodes into a plausible-looking value and, worse,
+/// leaves the reader mid-record so that everything after it in the stream is garbage.
+pub fn read_as_tlv<T: TlvType + Readable, R: Read>(reader: &mut R) -> Result<T, DecodeError> {
+    let tlv_type: BigSize = Readable::read(reader)?;
+    if tlv_type.0 != T::TYPE_ID as u64 {
+        return Err(DecodeError::InvalidValue);
+    }
+    let len: BigSize = Readable::read(reader)?;
+    read_tlv_body(reader, len.0)
+}
+
+/// Reads the body of a TLV record whose header has already been consumed.
+///
+/// The value is read through a reader bounded to `len` bytes, so a body that reads past
+/// its declared length fails rather than stealing bytes from the next record, and a body
+/// that stops short is rejected instead of leaving the remainder to be misread.
+pub fn read_tlv_body<T: Readable, R: Read>(reader: &mut R, len: u64) -> Result<T, DecodeError> {
+    let mut body = lightning::util::ser::FixedLengthReader::new(reader, len);
+    let value = T::read(&mut body)?;
+    if body.bytes_remain() {
+        return Err(DecodeError::InvalidValue);
+    }
+    Ok(value)
 }
 
 /// Writes a [`HashMap`].

--- a/dlc-messages/src/ser_macros.rs
+++ b/dlc-messages/src/ser_macros.rs
@@ -194,6 +194,38 @@ macro_rules! impl_dlc_writeable_external_enum {
     };
 }
 
+/// Declares a type as a TLV record, giving it its record type in one place.
+///
+/// Use this for any type the DLC specification assigns a TLV record type to. It
+/// implements [`TlvType`](crate::ser_impls::TlvType) with the given constant and derives
+/// [`Type`](lightning::ln::wire::Type) from it, so the two can never disagree.
+///
+/// Declaring it also brings in [`TlvRecord`](crate::ser_impls::TlvRecord) through that
+/// trait's blanket impl, which is what lets the type be read and written on its own
+/// as well as nested. A type that only ever appears nested loses nothing by having it.
+///
+/// ```ignore
+/// impl_dlc_tlv_record!(OracleAnnouncement, ANNOUNCEMENT_TYPE);
+/// ```
+///
+/// Do not reach for this to mark a peer-to-peer protocol message. Those are wire
+/// messages — a `u16` type and no length — and want a bare
+/// [`Type`](lightning::ln::wire::Type) impl instead.
+#[macro_export]
+macro_rules! impl_dlc_tlv_record {
+    ($st:ident, $type_id:expr) => {
+        impl $crate::ser_impls::TlvType for $st {
+            const TYPE_ID: u16 = $type_id;
+        }
+
+        impl ::lightning::ln::wire::Type for $st {
+            fn type_id(&self) -> u16 {
+                <$st as $crate::ser_impls::TlvType>::TYPE_ID
+            }
+        }
+    };
+}
+
 /// Implements the [`lightning::util::ser::Writeable`] trait for an enum as a TLV.
 #[macro_export]
 macro_rules! impl_dlc_writeable_enum_as_tlv {
@@ -216,8 +248,8 @@ macro_rules! impl_dlc_writeable_enum_as_tlv {
                 let id: $crate::ser_impls::BigSize = Readable::read(r)?;
                 match id.0 {
                     $($variant_id => {
-                        let _ : $crate::ser_impls::BigSize = Readable::read(r)?;
-						Ok($st::$variant_name(Readable::read(r)?))
+                        let len : $crate::ser_impls::BigSize = Readable::read(r)?;
+						Ok($st::$variant_name($crate::ser_impls::read_tlv_body(r, len.0)?))
 					}),*
 					_ => {
 						Err(DecodeError::UnknownRequiredFeature)

--- a/docs/oracle-message-serialization.md
+++ b/docs/oracle-message-serialization.md
@@ -1,0 +1,135 @@
+# Oracle message serialization
+
+An oracle announcement or attestation is written in two different, both correct,
+forms. Confusing the two is what led every consumer of these crates to hand-roll
+the same header-stripping workaround. This page states which form goes where, and
+what a consumer holding old bytes has to do.
+
+## The two forms
+
+**Body form.** `Writeable`/`Readable` on `OracleAnnouncement`, `OracleEvent` and
+`OracleAttestation` handle the message fields alone, with no header:
+
+```
+announcement_signature (64) || oracle_public_key (32) || oracle_event (TLV)
+```
+
+**TLV form.** The same body behind a header carrying the record type and the body
+length, both as `BigSize`:
+
+```
+BigSize(55332) || BigSize(body_len) || body
+```
+
+| Message | Record type |
+| --- | --- |
+| `OracleAnnouncement` | 55332 |
+| `OracleEvent` | 55330 |
+| `OracleAttestation` | 55400 |
+
+## Which form goes where
+
+Inside a contract, an announcement is stored in the TLV form — but the header comes
+from `write_as_tlv`, which `SingleOracleInfo` and `MultiOracleInfo` wrap the field
+in, not from the `Writeable` impl. So the impl must keep writing the body alone. If
+it wrote a header too, every contract would carry it twice and no previously stored
+contract would load. That is the trap the earlier `oracle-msg-as-tlv` attempt fell
+into, and why it had to regenerate all six contract fixtures.
+
+Everywhere the message travels on its own — an oracle's HTTP response, a nostr
+event, a `BYTEA` column, a hex string in an RPC — the TLV form is correct. It is
+what other DLC implementations emit, and it is the form the announcement
+signature commits to.
+
+## Reading and writing the standalone form
+
+Use `TlvRecord`. It exists so that nobody has to know the above:
+
+```rust
+use ddk_messages::oracle_msgs::OracleAnnouncement;
+use ddk_messages::TlvRecord;
+
+let announcement = OracleAnnouncement::from_tlv_hex(&response.hex)?;
+let bytes = announcement.to_tlv_bytes();
+```
+
+Do not reach for `OracleAnnouncement::read` on bytes that arrived on their own.
+It reads the body form, so it will fail on a TLV record, and stripping the two
+`BigSize` fields by hand to make it work is the workaround this trait replaces.
+
+`read_as_tlv` now checks both halves of the header: the record type must match the
+type being read, and the body must consume exactly the declared number of bytes.
+A truncated or mistyped record fails outright instead of decoding into a plausible
+value and leaving the reader mid-record.
+
+## Migrating stored bytes
+
+**Contracts need no migration.** A contract's announcements were always written in
+the embedded body form and read back the same way. `stored_contracts_round_trip_byte_for_byte`
+in `ddk/src/util/ser.rs` reads each contract state from a fixture serialized by an
+earlier release and writes it back, asserting every byte matches; a production
+announcement likewise round-trips to the exact hex its oracle signed. While those
+pass, a `contract_data` column holds what this code expects.
+
+(The fixtures under `testconfig/contract_binaries/old/` are a separate matter. All
+but `Offered` stopped deserializing some time ago because of unrelated changes to
+the contract structs, and that was already true before any of this.)
+
+**Standalone oracle bytes may need one.** A store that persisted announcements or
+attestations on their own holds the body form if it was written through
+`Writeable::encode`, the TLV form if it was written from an oracle's own bytes, and
+a mix if it has seen both. `TlvRecord::from_tlv_bytes_or_legacy` reads either:
+
+```rust
+let announcement = OracleAnnouncement::from_tlv_bytes_or_legacy(&row.bytes)?;
+```
+
+The two are told apart by the header, which a body cannot imitate: a body opens
+with a Schnorr signature or a string length, neither of which encodes the record
+type as a `BigSize` and then accounts for the buffer exactly.
+
+To migrate such a column, read every row with `from_tlv_bytes_or_legacy` and write
+it back with `to_tlv_bytes`. Once no legacy rows remain, switch the read path to
+`from_tlv_bytes` so a malformed row is reported rather than guessed at.
+
+## Nostr events
+
+Kormir publishes announcements (kind 88) and attestations (kind 89) as base64 of
+the TLV form, so other DLC clients on the relay can read them. Events published
+before this carry the body form, and a relay's history cannot be rewritten, so
+readers use `from_tlv_bytes_or_legacy`.
+
+## Adding a new type in this position
+
+`oracle_announcement` is the only type in the specification today that is all three of
+"has its own record type", "nested inside another message" and "travels standalone".
+A v2 message could well be the second, so the handling is structural rather than
+special-cased.
+
+Declare the record type once:
+
+```rust
+impl_dlc_tlv_record!(MyMessage, MY_MESSAGE_TYPE);
+```
+
+That implements `TlvType` with the constant and derives `Type` from it, so the two
+cannot drift apart. `TlvRecord` then arrives through its blanket impl over
+`TlvType + Readable + Writeable`, so the standalone form needs no further code — there
+is nothing to remember and nothing to forget. Keep the `Writeable` impl body-only, and
+nest the field with `write_as_tlv`/`read_as_tlv` as usual.
+
+Two things this macro is not for:
+
+- **Peer-to-peer protocol messages.** `OfferDlc`, `AcceptDlc`, `SignDlc` and the channel
+  messages are *wire messages*: a `u16` type and the body, with no length. That is a
+  different framing, and the `Message` enum plus the wire read/write path already add
+  and strip the prefix in one place — which is precisely why those types never grew this
+  problem despite also being body-only. Give them a bare `Type` impl.
+- **Types that never travel alone.** `EventDescriptor` is nested with a header but is
+  never standalone, so nobody ever tried to read one by itself. Declaring the record
+  type costs nothing, but the standalone methods will simply go unused.
+
+Before relying on `from_tlv_bytes_or_legacy` for a new type, check its precondition:
+the body must not be able to begin with the record's own type id as a `BigSize` followed
+by a length that accounts for the buffer exactly. It holds for the oracle messages,
+whose bodies open with a Schnorr signature or a string length.

--- a/kormir/src/nostr_events.rs
+++ b/kormir/src/nostr_events.rs
@@ -1,16 +1,22 @@
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use ddk_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation};
-use lightning::util::ser::Writeable;
+use ddk_messages::TlvRecord;
 use nostr::event::Error;
 use nostr::{Event, EventBuilder, EventId, Keys, Kind, Tag};
 
-/// Creates an Oracle Attestation event for nostr.
+/// Creates an Oracle Announcement event for nostr.
+///
+/// The content is the announcement in its standalone TLV form, base64 encoded, which
+/// is what other DLC clients on the relay expect to find there. Events published
+/// before this carried the TLV body with no header; read them back with
+/// [`TlvRecord::from_tlv_bytes_or_legacy`], since a relay's history cannot be
+/// rewritten.
 pub fn create_announcement_event(
     keys: &Keys,
     announcement: &OracleAnnouncement,
 ) -> Result<Event, Error> {
-    let content = announcement.encode();
+    let content = announcement.to_tlv_bytes();
     let event = EventBuilder::new(Kind::Custom(88), BASE64.encode(content))
         .build(keys.public_key)
         .sign_with_keys(keys)?;
@@ -18,15 +24,48 @@ pub fn create_announcement_event(
 }
 
 /// Creates an Oracle Attestation event for nostr.
+///
+/// As with [`create_announcement_event`], the content is the standalone TLV form.
 pub fn create_attestation_event(
     keys: &Keys,
     attestation: &OracleAttestation,
     event_id: EventId,
 ) -> Result<Event, Error> {
-    let content = attestation.encode();
+    let content = attestation.to_tlv_bytes();
     let event = EventBuilder::new(Kind::Custom(89), BASE64.encode(content))
         .tag(Tag::event(event_id))
         .build(keys.public_key)
         .sign_with_keys(keys)?;
     Ok(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ddk_messages::oracle_msgs::ANNOUNCEMENT_TYPE;
+
+    const REAL_ANNOUNCEMENT_HEX: &str = "fdd824fd012a73740e61118e5d1c2c223c986b859a42c2cca56cb621d13ff8880ea856caf24aa29bc36a1e0d5c471b6a2baa68f98a413362c4e6a97f13c04b186395e9e0d8fcc3d07289c2ade25405c1c421b38c9322cd73fb2c89f42ce0730a35fae1f8875dfdd822c60001529fadc9958e1e1cf8ea29f05a25d67e04a0c21dcbfcb99b8b24d32f274795eb68e81101fdd8064e0004086e6f742d70616964067265706169641d6c6971756964617465642d62792d6d617475726174696f6e2d646174651d6c6971756964617465642d62792d70726963652d7468726573686f6c644d6c6f616e2d6d6174757265642d38313233313935633631653439376631323465623764336266626531323232613530326233306162343139363766306466323036306133656533366635623063";
+
+    /// The relay carries the announcement in the same bytes the oracle would serve
+    /// over HTTP, so a client reading the event needs no knowledge of kormir.
+    #[test]
+    fn announcement_event_content_is_the_standalone_tlv_record() {
+        let announcement = OracleAnnouncement::from_tlv_hex(REAL_ANNOUNCEMENT_HEX).unwrap();
+        let event = create_announcement_event(&Keys::generate(), &announcement).unwrap();
+
+        let content = BASE64.decode(&event.content).unwrap();
+        assert_eq!(content, announcement.to_tlv_bytes());
+        assert_eq!(
+            &content[..3],
+            &[
+                0xfd,
+                (ANNOUNCEMENT_TYPE >> 8) as u8,
+                ANNOUNCEMENT_TYPE as u8
+            ]
+        );
+        assert_eq!(
+            OracleAnnouncement::from_tlv_bytes(&content).unwrap(),
+            announcement
+        );
+    }
 }

--- a/plans/custom-tlv-stream.md
+++ b/plans/custom-tlv-stream.md
@@ -1,0 +1,315 @@
+---
+title: "Custom TLV Streams in DLC Messages"
+type: plan
+updated: "2026-08-13"
+tags: [dlcdevkit, ddk-messages, tlv, serialization, interop, node-dlc, bal, stateless-contracts]
+status: proposed
+related: [[docs/oracle-message-serialization.md]]
+---
+
+# Custom TLV Streams in DLC Messages
+
+> **Goal:** Let an application attach its own TLV records to a DLC message, read them
+> back off a message it receives, and have records it does not understand survive
+> a round trip instead of being silently discarded.
+>
+> **Scope:** `ddk-messages` and the stateless `ddk::contract` module. The manager
+> path benefits without being touched.
+>
+> **Prerequisite:** landed. The TLV primitives this plan builds on
+> (`TlvType`, `TlvRecord`, `read_tlv_body`) shipped with the oracle message
+> serialization fix. See [[docs/oracle-message-serialization.md]].
+
+---
+
+## 1. Why We're Doing This
+
+### 1.1 Today's pain
+
+DDK silently drops application TLV records. Verified by appending one record
+(type 64999, 3-byte value, 7 bytes total) to a real `SignDlc` and reading it back:
+
+```
+read ok        = true
+consumed       19651 of 19658
+re-serialized  19651   ← the 7 bytes are gone
+```
+
+The message parses without complaint. `impl_dlc_writeable!` reads the declared
+fields, stops, and leaves the trailing bytes unread; writing produces the fields
+again and nothing else. There is no error and no warning at any layer. Nothing
+downstream can tell that data was lost.
+
+This matters concretely because our own counterparties send such records.
+node-dlc appends a TLV stream to `DlcSign`, `DlcOffer` and `DlcAccept` per
+dlcspecs PR #163, parsing what it knows (`BatchFundingGroup`) and retaining
+everything else:
+
+```ts
+// packages/messaging/lib/messages/DlcSign.ts — deserialize
+while (!reader.eof) {
+  const buf = getTlv(reader);
+  const { type } = deserializeTlv(new BufferReader(buf));
+  switch (Number(type)) {
+    case MessageType.BatchFundingGroup: /* parse */ break;
+    default:
+      instance.unknownTlvs.push({ type: Number(type), data: buf });
+  }
+}
+
+// serialize
+if (this.unknownTlvs) {
+  this.unknownTlvs.forEach((tlv) => writer.writeBytes(tlv.data));
+}
+```
+
+So a message that passes through DDK loses records a BAL peer expects to get
+back, and DDK applications have no way to carry their own context (a loan id, a
+lender reference) alongside a contract.
+
+### 1.2 The target state
+
+An application defines a record type in its own crate and uses it directly on
+the message structs the stateless API already hands it:
+
+```rust
+pub const LOAN_REF_TYPE: u16 = 65003;   // odd, application range
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoanRef {
+    pub loan_id: [u8; 16],
+    pub lender: String,
+}
+
+impl_dlc_writeable!(LoanRef, { (loan_id, writeable), (lender, string) });
+impl_dlc_tlv_record!(LoanRef, LOAN_REF_TYPE);
+```
+
+```rust
+// offering side
+let mut offer = ddk::contract::create_offer(params)?;
+offer.tlvs.set(&LoanRef { loan_id, lender });
+// the application already persists the message; the record rides along
+
+// accepting side
+let loan_ref: Option<LoanRef> = offer.tlvs.get()?;
+```
+
+And a record DDK does not recognise is preserved verbatim rather than dropped.
+
+### 1.3 Non-goals
+
+- **Interpreting unknown records.** They are held as `(type, bytes)` and written
+  back unchanged. DDK does not validate them.
+- **Manager or transport API.** No builder hook, no message callback, no change
+  to `send_dlc_offer`. See §3 for why this is not a compromise.
+- **Contract persistence.** Records do not ride `OfferedContract` →
+  `AcceptedContract` → `SignedContract`. See §3.
+- **Parsing node-dlc's `BatchFundingGroup`.** It becomes an unknown record that
+  round-trips correctly. Giving it a typed field is separate work.
+
+---
+
+## 2. What Already Exists
+
+The oracle serialization work put three of the four required pieces in place.
+
+| Piece | Where | Status |
+|---|---|---|
+| Length-bounded body reads | `ser_impls::read_tlv_body` via `FixedLengthReader` | done |
+| Compile-time record type for dispatch | `ser_impls::TlvType::TYPE_ID` | done |
+| Standalone encode/decode per record | `ser_impls::TlvRecord`, blanket impl | done |
+| Stream container + message field | — | this plan |
+
+`read_tlv_body` is the load-bearing one. Before it, `read_as_tlv` discarded the
+declared length, so there was no way to skip a record whose shape you do not
+know — which is exactly what node-dlc's `getTlv(reader)` does. Everything here
+depends on being able to consume an unknown record by its length alone.
+
+The message boundary that "read until EOF" needs already exists too:
+`message_handler.rs:182` wraps the body in `FixedLengthReader::new(&mut buf, remaining)`
+before dispatching, and the nostr path reads from a cursor over exactly the
+message bytes.
+
+---
+
+## 3. Why the Stateless Module Is the Right Home
+
+This was the decision that made the work small.
+
+Through the **manager**, an application never touches a raw message.
+`send_dlc_offer` builds the offer inside the manager actor and the transport
+sends it — the `OfferDlc` comes back after it has already gone out, so there is
+nowhere to attach anything. `Transport::start` hands an incoming message straight
+to `manager.on_dlc_message`, so nothing sees it on the way in. What the
+application eventually reads is an `OfferedContract` out of storage. Supporting
+custom records there would mean a builder hook, a receive callback, and threading
+the records through every contract struct so they survive to storage — which
+changes `contract_data` and needs a migration.
+
+Through the **stateless `ddk::contract` module**, none of that applies. Its
+premise is already that "the three wire messages are the authoritative state":
+`create_offer` returns an owned `OfferDlc`, `accept_offer` takes `&OfferDlc`, and
+the application persists the messages itself. Put a field on the message and the
+application can use it — no new API of any kind.
+
+The manager path still gains relay fidelity for free: it stops discarding records
+it does not understand. It just cannot surface them to an application, which is
+acceptable because it is not the module an application would use for this.
+
+**`OfferedContract` does not embed `OfferDlc`** (`ddk-manager/src/contract/offered_contract.rs:26-55`);
+it decomposes the offer into its own fields. So a field on the message never
+reaches `contract_data`, and `stored_contracts_round_trip_byte_for_byte` keeps
+passing. No migration.
+
+---
+
+## 4. Design
+
+### 4.1 `TlvStream`
+
+```rust
+/// The TLV records at the end of a message.
+///
+/// Records whose type this build knows are still parsed into their own fields;
+/// this holds the rest, verbatim, so they survive a round trip.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TlvStream {
+    records: Vec<(u64, Vec<u8>)>,   // (type, full record bytes), ascending by type
+}
+
+impl TlvStream {
+    pub fn is_empty(&self) -> bool;
+
+    /// Reads records until the reader is exhausted.
+    pub fn read_to_end<R: Read>(reader: &mut R) -> Result<Self, DecodeError>;
+
+    /// Parses the record whose type is `T::TYPE_ID`, if present.
+    pub fn get<T: TlvRecord>(&self) -> Result<Option<T>, DecodeError>;
+
+    /// Writes `value`, replacing any existing record of the same type.
+    pub fn set<T: TlvRecord>(&mut self, value: &T);
+
+    pub fn remove(&mut self, type_id: u16) -> bool;
+
+    /// Raw access for records with no Rust type in this build.
+    pub fn raw(&self) -> impl Iterator<Item = (u64, &[u8])>;
+}
+```
+
+`get`/`set` key off `TlvRecord::TYPE_ID`, so there is no runtime registry to
+populate and no way to read a record at the wrong type.
+
+Records are held sorted by type, which is what the TLV stream rules require and
+what makes `write` deterministic — important because a message's bytes are
+compared for equality in several places.
+
+### 4.2 Message field
+
+A new field kind in `impl_dlc_writeable!`, valid only as the final field:
+
+```rust
+impl_dlc_writeable!(SignDlc, SIGN_TYPE, {
+    (protocol_version, writeable),
+    (contract_id, writeable),
+    (cet_adaptor_signatures, writeable),
+    (refund_signature, writeable),
+    (funding_signatures, writeable),
+    (tlvs, tlv_stream)              // must be last
+});
+```
+
+`field_write!` writes every record; `field_read!` calls `TlvStream::read_to_end`.
+
+Applied to `OfferDlc`, `AcceptDlc` and `SignDlc` to start — the three messages
+node-dlc extends and the three the stateless module exchanges. The channel
+messages can follow if a need appears.
+
+### 4.3 Compatibility
+
+**Wire.** An empty stream writes zero bytes, so a message from a peer that uses
+no records is byte-identical to today, in both directions.
+
+**JSON.** The stateless module is what the FFI and mobile bindings use, and
+`ddk-node` returns messages as JSON, so the field needs
+`#[cfg_attr(feature = "use-serde", serde(default, skip_serializing_if = "TlvStream::is_empty"))]`.
+Old payloads without the field parse, and messages with no records serialize
+unchanged. `contract_flags` already uses this pattern at
+`ddk-manager/src/contract/offered_contract.rs:51`.
+
+Record bytes serialize as hex, matching the convention `serde_utils` already
+uses for byte fields.
+
+### 4.4 Macro hygiene
+
+`impl_dlc_writeable!` is `#[macro_export]`ed but is not usable from another crate
+as written. Its body references `Writeable`, `Writer`, `Readable`, `DecodeError`
+and `lightning::io::Read` unqualified (`dlc-messages/src/ser_macros.rs:82-102`),
+so a consumer needs all four in scope *and* `lightning` as a direct dependency at
+exactly the version `ddk-messages` resolves. A mismatch produces a confusing
+trait error far from its cause.
+
+Since defining a record type is the first thing an application does, this has to
+be fixed for the feature to be usable at all:
+
+- Fully qualify the macro internals (`::lightning::util::ser::Writeable`, etc.).
+- Re-export `lightning` and `ddk_messages` from `ddk` — today `ddk/src/lib.rs:47`
+  re-exports only `ddk_manager`, so a consumer must add `ddk-messages` to their
+  own manifest and keep its version in step by hand.
+
+---
+
+## 5. Open Decision
+
+**Unknown even types: reject or keep?**
+
+The Lightning convention is that an unknown even type must be rejected and an odd
+one may be ignored. node-dlc keeps everything regardless of parity.
+
+Recommendation: keep everything, and log a warning on an unknown even type.
+Interop with BAL is the point of the feature, DDK does not validate these
+records, and rejecting a message mid-protocol over a record we were never going
+to read is worse than carrying it. The warning means a genuinely required record
+we do not understand still surfaces.
+
+Decide before implementing — it changes `read_to_end` and the tests.
+
+---
+
+## 6. Tasks
+
+1. **Macro hygiene.** Qualify paths in `impl_dlc_writeable!`, `field_write!`,
+   `field_read!`. Re-export `lightning` and `ddk_messages` from `ddk`. Add a test
+   crate, or a doc test, that defines a record type using only `ddk` imports —
+   this is the regression guard for the whole consumer story.
+2. **`TlvStream`.** The type, `read_to_end`, `get`/`set`/`remove`/`raw`, ordering,
+   and the even/odd rule from §5. Unit tests: empty stream writes nothing;
+   unknown records round-trip verbatim; `get` at the wrong type returns `None`;
+   duplicate types rejected; truncated record rejected.
+3. **`tlv_stream` field kind.** Add to the field macros, rejecting use anywhere
+   but last.
+4. **Wire up the three messages.** `OfferDlc`, `AcceptDlc`, `SignDlc`, with the
+   serde attributes from §4.3.
+5. **Compatibility tests.** A message with an empty stream is byte-identical to
+   the pre-change encoding; existing `test_inputs/*.json` parse unchanged;
+   `stored_contracts_round_trip_byte_for_byte` still passes.
+6. **node-dlc interop.** Round-trip a real `DlcSign` carrying a
+   `BatchFundingGroup` record produced by node-dlc, asserting the bytes come back
+   identical. This is the test that would have caught the silent drop.
+7. **Stateless example.** Extend `ddk/src/contract/tests.rs` with a lifecycle that
+   attaches a record on the offer and reads it on the accept side, so the
+   documented consumer story is executed.
+8. **Docs.** A section in [[docs/oracle-message-serialization.md]], or a sibling
+   page, covering how to define a record type and the application type range.
+
+---
+
+## 7. Notes
+
+- Type range: applications should use odd types in the custom range to avoid
+  colliding with anything the specification assigns. The example uses 65003.
+- This does not make DDK a validating relay. A record it carries has been checked
+  for framing only — length and uniqueness — never for meaning.
+- If an application later needs records to survive into the manager's stored
+  contracts, that is the larger piece of work described in §3, and it does need a
+  `contract_data` migration. Nothing here forecloses it.


### PR DESCRIPTION
## Summary

`OracleAnnouncement` is the one type in the DLC specification that has its own record type, is nested inside another message, *and* travels on its own. Those two roles pull in opposite directions: nested, its `Writeable` impl must write the body alone because `SingleOracleInfo` wraps the field in `write_as_tlv`; standalone, it needs the header because nothing else supplies one. One impl cannot do both, so there was no supported way to read an announcement that arrived by itself and every consumer hand-rolled the same two `BigSize` reads to strip the header.

This adds the missing second entry point instead of changing the impl. The on-disk contract format is untouched, so there is no data migration.

## Changes

- **`TlvType`** gives a record its type as an associated constant, which a reader holding only bytes can compare against. **`TlvRecord`** is a blanket impl over `TlvType + Readable + Writeable` supplying `to_tlv_bytes`, `from_tlv_bytes`, the hex forms, and `from_tlv_bytes_or_legacy` for stores holding a mix of both encodings. Declaring a record is one line of `impl_dlc_tlv_record!`, which derives `Type` from the same constant so the two cannot drift.
- **`read_as_tlv` now enforces the header.** The record type must match the type being read, and the body must consume exactly its declared length. It previously discarded both, so a mistyped or truncated record decoded into a plausible value *and* left the reader mid-record, corrupting everything after it.
- **Fixed a real interop bug in kormir's nostr events.** Announcements and attestations were published in the body form, unreadable by other DLC clients on the relay. They now carry the TLV form; the reader takes either, since relay history cannot be rewritten.
- Removed `write_oracle_event`, which duplicated `write_as_tlv` behind a misleading TODO.
- Added `docs/oracle-message-serialization.md` covering which form goes where and how to migrate a column holding standalone oracle bytes.
- Added `plans/custom-tlv-stream.md`. Separate finding: DDK silently drops application TLV records appended to a message — appending 7 bytes to a `SignDlc` parses fine, then re-serializes 7 bytes shorter. node-dlc preserves these. The plan scopes the fix to the stateless `ddk::contract` module, where it needs no manager or migration work.

## Note for the release notes

Two breaking changes no test can catch:

1. `read_as_tlv`'s bound moved from `T: Type` to `T: TlvType` — a compile break for direct callers.
2. kormir's nostr kind 88/89 payloads changed to the TLV form. DDK reads both; an external client with a body-only decoder does not.

## Testing

`cargo test --workspace --all-features` — 277 passing, 0 failures. Clippy and rustdoc clean.

Backward compatibility is pinned against bytes this crate did not write:

- Production Magnolia announcement and attestation, and node-dlc's own enum and **numeric** announcement vectors — all parse, validate where signed, and re-encode byte-identical. The numeric one covers `digit_decomposition_event_descriptor` (55306), which previously had no foreign-byte coverage at all; every other fixture takes the 55302 branch.
- `stored_contracts_round_trip_byte_for_byte` reads all six contract states from fixtures serialized by an earlier release and asserts every byte matches on write-back. This is the evidence that `contract_data` needs no migration.
- `legacy_body_form_nostr_events_still_decode` covers the path an existing relay client hits after the kormir change.
- `json_representation_is_unchanged` pins the camelCase JSON shape, which `KormirOracleClient` deserializes and nothing else guarded.

Reviewer note: the `#[ignore]`d `splice_in_*` execution tests do not terminate — verified they also time out at 25 minutes on unmodified `master`, so it is pre-existing and unrelated. The other 10 execution tests pass.
