### PR TITLE
wallet: implement the BDK wallet improvement plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip329"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac70750b23e4176d426b149e9c217af603c13a12100c79db82b794a6b27d55c"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bip39"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1083,7 @@ dependencies = [
  "bdk_chain",
  "bdk_esplora",
  "bdk_wallet",
+ "bip329",
  "bip39",
  "bitcoin",
  "bitcoincore-rpc",

--- a/ddk/Cargo.toml
+++ b/ddk/Cargo.toml
@@ -21,6 +21,7 @@ manager = [
     "ddk-manager/manager",
     "dep:kormir",
     "dep:bdk_esplora",
+    "dep:bip329",
     "dep:tokio",
     "dep:zeromq",
     "dep:uuid",
@@ -53,6 +54,7 @@ kormir = { workspace = true, optional = true }
 
 bitcoin = { workspace = true, features = ["std", "rand", "serde"] }
 bdk_esplora = { version = "0.22.2", default-features = false, features = ["std", "async-https", "tokio"], optional = true }
+bip329 = { version = "0.6.0", optional = true }
 bdk_wallet = "3.1.0"
 bdk_chain = "0.23.3"
 lightning = { workspace = true, features = ["std", "grind_signatures"] }

--- a/ddk/Cargo.toml
+++ b/ddk/Cargo.toml
@@ -53,7 +53,7 @@ kormir = { workspace = true, optional = true }
 
 bitcoin = { workspace = true, features = ["std", "rand", "serde"] }
 bdk_esplora = { version = "0.22.2", default-features = false, features = ["std", "async-https", "tokio"], optional = true }
-bdk_wallet = "3.0.0"
+bdk_wallet = "3.1.0"
 bdk_chain = "0.23.3"
 lightning = { workspace = true, features = ["std", "grind_signatures"] }
 serde = { workspace = true, features = ["std", "derive"] }

--- a/ddk/src/builder.rs
+++ b/ddk/src/builder.rs
@@ -42,6 +42,7 @@ pub struct Builder<T, S, O> {
     zmq_blockhash_endpoint: Option<String>,
     network: Network,
     seed_bytes: [u8; 64],
+    wallet_config: crate::wallet::WalletConfig,
     logger: Option<Arc<Logger>>,
 }
 
@@ -62,6 +63,7 @@ impl<T: Transport, S: Storage, O: Oracle> Default for Builder<T, S, O> {
             zmq_blockhash_endpoint: None,
             network: DEFAULT_NETWORK,
             seed_bytes: [0u8; 64],
+            wallet_config: crate::wallet::WalletConfig::default(),
             logger: None,
         }
     }
@@ -150,6 +152,13 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
         Ok(self)
     }
 
+    /// Set the smallest change output the wallet's coin selection
+    /// creates; smaller change goes to fees. Defaults to 25 000 sats.
+    pub fn set_min_change_size(&mut self, min_change_size: u64) -> &mut Self {
+        self.wallet_config.min_change_size = min_change_size;
+        self
+    }
+
     /// Set the logger for the DDK instance.
     pub fn set_logger(&mut self, logger: Arc<Logger>) -> &mut Self {
         self.logger = Some(logger);
@@ -201,31 +210,18 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
             logger.clone(),
         )?);
 
-        let wallet = match &self.contract_address_generator {
-            Some(w) => {
-                let wallet = DlcDevKitWallet::new(
-                    &self.seed_bytes,
-                    esplora_client.clone(),
-                    self.network,
-                    storage.clone(),
-                    Some(w.clone()),
-                    logger.clone(),
-                )
-                .await?;
-                Arc::new(wallet)
-            }
-            None => Arc::new(
-                DlcDevKitWallet::new(
-                    &self.seed_bytes,
-                    esplora_client.clone(),
-                    self.network,
-                    storage.clone(),
-                    None,
-                    logger.clone(),
-                )
-                .await?,
-            ),
-        };
+        let wallet = Arc::new(
+            DlcDevKitWallet::new_with_config(
+                &self.seed_bytes,
+                esplora_client.clone(),
+                self.network,
+                storage.clone(),
+                self.contract_address_generator.clone(),
+                self.wallet_config,
+                logger.clone(),
+            )
+            .await?,
+        );
 
         let mut oracles = HashMap::new();
         oracles.insert(oracle.get_public_key(), oracle.clone());

--- a/ddk/src/chain/esplora.rs
+++ b/ddk/src/chain/esplora.rs
@@ -38,6 +38,7 @@ fn esplora_timeout_secs() -> u64 {
 pub struct EsploraClient {
     pub async_client: AsyncClient,
     network: Network,
+    fees: super::FeeRateCache,
     logger: Arc<Logger>,
 }
 
@@ -52,8 +53,23 @@ impl EsploraClient {
         Ok(EsploraClient {
             async_client,
             network,
+            fees: super::FeeRateCache::new(),
             logger,
         })
+    }
+
+    /// Fetches the fee estimates from esplora into the fee rate cache.
+    /// A failed fetch keeps the cached rates and logs a warning: fee
+    /// estimation must not fail a sync.
+    pub async fn refresh_fee_estimates(&self) {
+        match self.async_client.get_fee_estimates().await {
+            Ok(estimates) => self.fees.update(&estimates),
+            Err(e) => log_warn!(
+                self.logger,
+                "Could not fetch fee estimates. error={}",
+                e.to_string()
+            ),
+        }
     }
 }
 
@@ -193,7 +209,7 @@ impl ddk_manager::Blockchain for EsploraClient {
 }
 
 impl FeeEstimator for EsploraClient {
-    fn get_est_sat_per_1000_weight(&self, _confirmation_target: ConfirmationTarget) -> u32 {
-        1
+    fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
+        self.fees.get(confirmation_target)
     }
 }

--- a/ddk/src/chain/fees.rs
+++ b/ddk/src/chain/fees.rs
@@ -1,0 +1,136 @@
+//! Live fee estimation with hardcoded floors.
+//!
+//! Each sync fetches the fee estimates from esplora and caches one rate per
+//! [`ConfirmationTarget`]. The old hardcoded rates stay as floors: an
+//! estimate never drops a rate below its floor, and the floors serve as the
+//! fallback while no estimate has arrived.
+
+use lightning::chain::chaininterface::ConfirmationTarget;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// The minimum fee rate in sats per 1000 weight units (1 sat/vB).
+pub const MIN_FEERATE: u32 = 253;
+
+/// Every confirmation target with the esplora block target its estimate
+/// comes from and the floor (in sats per 1000 weight units) the cached rate
+/// never goes below.
+const TARGETS: [(ConfirmationTarget, u16, u32); 8] = [
+    (ConfirmationTarget::MaximumFeeEstimate, 1, 5_000),
+    (ConfirmationTarget::UrgentOnChainSweep, 1, 5_000),
+    (ConfirmationTarget::OutputSpendingFee, 6, 2_000),
+    (ConfirmationTarget::NonAnchorChannelFee, 6, 2_000),
+    (ConfirmationTarget::AnchorChannelFee, 12, MIN_FEERATE),
+    (ConfirmationTarget::ChannelCloseMinimum, 144, MIN_FEERATE),
+    (
+        ConfirmationTarget::MinAllowedAnchorChannelRemoteFee,
+        1008,
+        MIN_FEERATE,
+    ),
+    (
+        ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee,
+        1008,
+        MIN_FEERATE,
+    ),
+];
+
+/// A lock-free cache of fee rates per confirmation target.
+#[derive(Debug)]
+pub struct FeeRateCache {
+    fees: HashMap<ConfirmationTarget, AtomicU32>,
+}
+
+impl Default for FeeRateCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FeeRateCache {
+    /// Creates a cache seeded with the floor rates.
+    pub fn new() -> Self {
+        let fees = TARGETS
+            .iter()
+            .map(|(target, _, floor)| (*target, AtomicU32::new(*floor)))
+            .collect();
+        Self { fees }
+    }
+
+    /// Updates the cache from esplora fee estimates (block target to
+    /// sat/vB). Targets without a usable estimate keep their last rate.
+    pub fn update(&self, estimates: &HashMap<u16, f64>) {
+        for (target, blocks, floor) in TARGETS.iter() {
+            if let Some(sat_per_vb) = best_estimate(estimates, *blocks) {
+                let sat_per_kw = ((sat_per_vb * 250.0).round() as u32).max(*floor);
+                self.fees
+                    .get(target)
+                    .expect("every target is initialized")
+                    .store(sat_per_kw, Ordering::Release);
+            }
+        }
+    }
+
+    /// The cached fee rate in sats per 1000 weight units.
+    pub fn get(&self, confirmation_target: ConfirmationTarget) -> u32 {
+        self.fees
+            .get(&confirmation_target)
+            .map(|rate| rate.load(Ordering::Acquire))
+            .unwrap_or(MIN_FEERATE)
+    }
+}
+
+/// The estimate at the largest block target at or below `blocks`, falling
+/// back to the tightest (highest-fee) estimate available.
+fn best_estimate(estimates: &HashMap<u16, f64>, blocks: u16) -> Option<f64> {
+    estimates
+        .iter()
+        .filter(|(target, _)| **target <= blocks)
+        .max_by_key(|(target, _)| **target)
+        .or_else(|| estimates.iter().min_by_key(|(target, _)| **target))
+        .map(|(_, sat_per_vb)| *sat_per_vb)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floors_hold_without_estimates() {
+        let cache = FeeRateCache::new();
+        assert_eq!(cache.get(ConfirmationTarget::UrgentOnChainSweep), 5_000);
+        assert_eq!(cache.get(ConfirmationTarget::MaximumFeeEstimate), 5_000);
+        assert_eq!(cache.get(ConfirmationTarget::OutputSpendingFee), 2_000);
+        assert_eq!(
+            cache.get(ConfirmationTarget::ChannelCloseMinimum),
+            MIN_FEERATE
+        );
+    }
+
+    #[test]
+    fn estimates_update_and_convert_to_sat_per_kw() {
+        let cache = FeeRateCache::new();
+        let estimates = HashMap::from([(1u16, 50.0), (6u16, 20.0), (144u16, 2.0)]);
+        cache.update(&estimates);
+
+        // 50 sat/vB = 12500 sat/kw for the one-block targets.
+        assert_eq!(cache.get(ConfirmationTarget::UrgentOnChainSweep), 12_500);
+        // 20 sat/vB = 5000 sat/kw for the six-block targets.
+        assert_eq!(cache.get(ConfirmationTarget::NonAnchorChannelFee), 5_000);
+        // The 12-block target falls back to the six-block estimate.
+        assert_eq!(cache.get(ConfirmationTarget::AnchorChannelFee), 5_000);
+        // 2 sat/vB = 500 sat/kw for the long targets.
+        assert_eq!(cache.get(ConfirmationTarget::ChannelCloseMinimum), 500);
+    }
+
+    #[test]
+    fn estimates_never_drop_below_the_floor() {
+        let cache = FeeRateCache::new();
+        let estimates = HashMap::from([(1u16, 0.5)]);
+        cache.update(&estimates);
+        assert_eq!(cache.get(ConfirmationTarget::UrgentOnChainSweep), 5_000);
+        assert_eq!(
+            cache.get(ConfirmationTarget::ChannelCloseMinimum),
+            MIN_FEERATE
+        );
+    }
+}

--- a/ddk/src/chain/mod.rs
+++ b/ddk/src/chain/mod.rs
@@ -1,5 +1,7 @@
 mod esplora;
+mod fees;
 mod zmq;
 
 pub use esplora::EsploraClient;
+pub use fees::{FeeRateCache, MIN_FEERATE};
 pub use zmq::{ZeromqClient, ZeromqMessage};

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -242,6 +242,41 @@ where
             }
         });
 
+        // Spawn the wallet event listener: a transaction event (confirmed,
+        // unconfirmed, replaced, dropped) triggers the manager's periodic
+        // check right away instead of waiting for the next timer tick.
+        let processor = self.sender.clone();
+        let logger = self.logger.clone();
+        let mut wallet_events = self.wallet.subscribe_events();
+        runtime.spawn(async move {
+            use crate::wallet::WalletEvent;
+            use tokio::sync::broadcast::error::RecvError;
+            loop {
+                match wallet_events.recv().await {
+                    Ok(WalletEvent::ChainTipChanged { .. }) => continue,
+                    Ok(event) => {
+                        log_debug!(
+                            logger,
+                            "Wallet event triggers a periodic check. event={:?}",
+                            event
+                        );
+                        let _ = processor
+                            .send(DlcManagerMessage::PeriodicCheck)
+                            .await
+                            .map_err(|e| {
+                                log_error!(
+                                    logger,
+                                    "Error sending periodic check: error={}",
+                                    e.to_string()
+                                );
+                            });
+                    }
+                    Err(RecvError::Lagged(_)) => continue,
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        });
+
         // Spawn contract monitor thread (30-second interval)
         let processor = self.sender.clone();
         let logger = self.logger.clone();

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -388,6 +388,15 @@ where
         Ok((contract_id, counter_party, accept_dlc))
     }
 
+    /// Lists the tracked contract funding outputs with their chain state,
+    /// so a consumer (node, FFI) can show locked collateral per contract
+    /// and observe a close.
+    pub async fn contract_utxos(
+        &self,
+    ) -> Result<Vec<crate::wallet::contract_tracker::ContractUtxo>> {
+        Ok(self.wallet.contract_utxos().await?)
+    }
+
     /// Refunds a DLC contract.
     ///
     /// This method checks if the refund locktime has passed and broadcasts the refund transaction if it has.

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -33,7 +33,7 @@ use crate::wallet::DlcDevKitWallet;
 use crate::{Oracle, Storage, Transport};
 use bitcoin::hex::DisplayHex;
 use bitcoin::secp256k1::PublicKey;
-use bitcoin::{Amount, Network, SignedAmount};
+use bitcoin::{Network, SignedAmount};
 use ddk_manager::contract::Contract;
 use ddk_manager::error::Error as ManagerError;
 use ddk_manager::{
@@ -410,22 +410,6 @@ where
         let wallet_balance = self.wallet.get_balance().await?;
         let contracts = self.storage.get_contracts().await?;
 
-        let contract = &contracts
-            .iter()
-            .map(|contract| match contract {
-                Contract::Confirmed(c) => {
-                    let accept_party_collateral = c.accepted_contract.accept_params.collateral;
-                    let total_collateral = c.accepted_contract.offered_contract.total_collateral;
-                    if c.accepted_contract.offered_contract.is_offer_party {
-                        total_collateral - accept_party_collateral
-                    } else {
-                        accept_party_collateral
-                    }
-                }
-                _ => Amount::ZERO,
-            })
-            .sum::<Amount>();
-
         let contract_pnl = &contracts
             .iter()
             .map(|contract| contract.get_pnl())
@@ -437,7 +421,8 @@ where
             foreign_unconfirmed: wallet_balance.untrusted_pending,
             spendable: wallet_balance.spendable,
             reserved: wallet_balance.reserved,
-            contract: contract.to_owned(),
+            contract_confirmed: wallet_balance.contract_confirmed,
+            contract_pending: wallet_balance.contract_pending,
             contract_pnl: contract_pnl.to_owned().to_sat(),
         })
     }

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -432,6 +432,22 @@ where
         Ok(self.wallet.contract_utxos().await?)
     }
 
+    /// Stores a BIP-329 label for a transaction, address, or output,
+    /// replacing an existing label with the same reference.
+    pub async fn set_label(&self, label: bip329::Label) -> Result<()> {
+        Ok(self.storage.persist_label(&label).await?)
+    }
+
+    /// Every BIP-329 label in storage.
+    pub async fn labels(&self) -> Result<bip329::Labels> {
+        Ok(self.storage.load_labels().await?)
+    }
+
+    /// Deletes the BIP-329 label of a reference.
+    pub async fn delete_label(&self, label_ref: &bip329::LabelRef) -> Result<()> {
+        Ok(self.storage.delete_label(label_ref).await?)
+    }
+
     /// Refunds a DLC contract.
     ///
     /// This method checks if the refund locktime has passed and broadcasts the refund transaction if it has.

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -435,6 +435,8 @@ where
             confirmed: wallet_balance.confirmed,
             change_unconfirmed: wallet_balance.immature + wallet_balance.trusted_pending,
             foreign_unconfirmed: wallet_balance.untrusted_pending,
+            spendable: wallet_balance.spendable,
+            reserved: wallet_balance.reserved,
             contract: contract.to_owned(),
             contract_pnl: contract_pnl.to_owned().to_sat(),
         })

--- a/ddk/src/ddk.rs
+++ b/ddk/src/ddk.rs
@@ -448,6 +448,23 @@ where
         Ok(self.storage.delete_label(label_ref).await?)
     }
 
+    /// Exports every BIP-329 label as JSONL, one label per line.
+    pub async fn export_labels(&self) -> Result<String> {
+        let labels = self.storage.load_labels().await?;
+        labels.export().map_err(|e| Error::Generic(e.to_string()))
+    }
+
+    /// Imports BIP-329 JSONL labels, replacing stored labels with the
+    /// same reference.
+    pub async fn import_labels(&self, jsonl: &str) -> Result<()> {
+        let labels =
+            bip329::Labels::try_from_str(jsonl).map_err(|e| Error::Generic(e.to_string()))?;
+        for label in labels.iter() {
+            self.storage.persist_label(label).await?;
+        }
+        Ok(())
+    }
+
     /// Refunds a DLC contract.
     ///
     /// This method checks if the refund locktime has passed and broadcasts the refund transaction if it has.

--- a/ddk/src/error.rs
+++ b/ddk/src/error.rs
@@ -209,6 +209,8 @@ pub enum WalletError {
     CoinSelection(#[from] bdk_wallet::coin_selection::InsufficientFunds),
     #[error("Coin control: {0}")]
     AddUtxo(#[from] bdk_wallet::tx_builder::AddUtxoError),
+    #[error("Fee bump: {0}")]
+    FeeBump(#[from] bdk_wallet::error::BuildFeeBumpError),
     #[error("Invalid derivation index")]
     InvalidDerivationIndex,
     #[error("Invalid secret key")]

--- a/ddk/src/error.rs
+++ b/ddk/src/error.rs
@@ -207,6 +207,8 @@ pub enum WalletError {
     Sender(#[from] tokio::sync::mpsc::error::SendError<WalletCommand>),
     #[error("Coin selection: {0}")]
     CoinSelection(#[from] bdk_wallet::coin_selection::InsufficientFunds),
+    #[error("Coin control: {0}")]
+    AddUtxo(#[from] bdk_wallet::tx_builder::AddUtxoError),
     #[error("Invalid derivation index")]
     InvalidDerivationIndex,
     #[error("Invalid secret key")]

--- a/ddk/src/error.rs
+++ b/ddk/src/error.rs
@@ -205,6 +205,8 @@ pub enum WalletError {
     Receiver(#[from] tokio::sync::oneshot::error::RecvError),
     #[error("Wallet sender error: {0}")]
     Sender(#[from] tokio::sync::mpsc::error::SendError<WalletCommand>),
+    #[error("Coin selection: {0}")]
+    CoinSelection(#[from] bdk_wallet::coin_selection::InsufficientFunds),
     #[error("Invalid derivation index")]
     InvalidDerivationIndex,
     #[error("Invalid secret key")]

--- a/ddk/src/lib.rs
+++ b/ddk/src/lib.rs
@@ -241,8 +241,13 @@ pub struct Balance {
     /// transactions
     pub reserved: Amount,
 
-    /// Total amount currently locked in active DLC contracts
-    pub contract: Amount,
+    /// Confirmed contract funding outputs, from chain truth over the
+    /// tracked 2-of-2 funding outpoints
+    pub contract_confirmed: Amount,
+
+    /// Unconfirmed contract funding outputs, from chain truth over the
+    /// tracked 2-of-2 funding outpoints
+    pub contract_pending: Amount,
 
     /// Cumulative profit/loss from all closed contracts (in satoshis)
     /// Positive values indicate overall profit, negative values indicate loss

--- a/ddk/src/lib.rs
+++ b/ddk/src/lib.rs
@@ -46,6 +46,11 @@ pub mod wallet;
 
 pub use ddk_manager;
 
+/// BIP-329 wallet label types, re-exported for [`Storage`] implementors
+/// and consumers of the label API.
+#[cfg(feature = "manager")]
+pub use bip329;
+
 /// DDK object with all services
 #[cfg(feature = "manager")]
 pub use ddk::DlcDevKit;
@@ -190,6 +195,29 @@ pub trait Storage: ddk_manager::Storage + Send + Sync + std::fmt::Debug + 'stati
         &self,
         _changeset: &wallet::contract_tracker::ChangeSet,
     ) -> Result<(), WalletError> {
+        Ok(())
+    }
+
+    /// Loads every BIP-329 label.
+    ///
+    /// The default implementation stores no labels and returns an empty
+    /// set.
+    async fn load_labels(&self) -> Result<bip329::Labels, WalletError> {
+        Ok(bip329::Labels::default())
+    }
+
+    /// Stores a BIP-329 label, replacing an existing label with the same
+    /// reference.
+    ///
+    /// The default implementation drops the label.
+    async fn persist_label(&self, _label: &bip329::Label) -> Result<(), WalletError> {
+        Ok(())
+    }
+
+    /// Deletes the BIP-329 label of a reference.
+    ///
+    /// The default implementation does nothing.
+    async fn delete_label(&self, _label_ref: &bip329::LabelRef) -> Result<(), WalletError> {
         Ok(())
     }
 }

--- a/ddk/src/lib.rs
+++ b/ddk/src/lib.rs
@@ -233,6 +233,14 @@ pub struct Balance {
     /// Unconfirmed balance from external sources
     pub foreign_unconfirmed: Amount,
 
+    /// Unspent coins minus reserved coins: what a new transaction or
+    /// offer can spend
+    pub spendable: Amount,
+
+    /// Unspent coins locked for in-flight offers and signed funding
+    /// transactions
+    pub reserved: Amount,
+
     /// Total amount currently locked in active DLC contracts
     pub contract: Amount,
 

--- a/ddk/src/lib.rs
+++ b/ddk/src/lib.rs
@@ -170,6 +170,28 @@ pub trait Storage: ddk_manager::Storage + Send + Sync + std::fmt::Debug + 'stati
     /// - Updating UTXO set
     /// - Maintaining wallet metadata
     async fn persist_bdk(&self, changeset: &ChangeSet) -> Result<(), WalletError>;
+
+    /// Loads the contract UTXO tracker changeset.
+    ///
+    /// The default implementation returns an empty changeset: a backend
+    /// that does not persist the tracker rebuilds it from contract
+    /// storage and a chain sync on the next wallet sync.
+    async fn initialize_contract_tracker(
+        &self,
+    ) -> Result<wallet::contract_tracker::ChangeSet, WalletError> {
+        Ok(wallet::contract_tracker::ChangeSet::default())
+    }
+
+    /// Persists contract UTXO tracker changes.
+    ///
+    /// The default implementation drops the changeset; see
+    /// [`Storage::initialize_contract_tracker`].
+    async fn persist_contract_tracker(
+        &self,
+        _changeset: &wallet::contract_tracker::ChangeSet,
+    ) -> Result<(), WalletError> {
+        Ok(())
+    }
 }
 
 /// Interface for secure key material storage and retrieval.

--- a/ddk/src/storage/memory.rs
+++ b/ddk/src/storage/memory.rs
@@ -8,6 +8,7 @@ use std::sync::RwLock;
 pub struct MemoryStorage {
     bdk_data: RwLock<Option<bdk_wallet::ChangeSet>>,
     contract_tracker: RwLock<crate::wallet::contract_tracker::ChangeSet>,
+    labels: RwLock<std::collections::BTreeMap<String, bip329::Label>>,
     contracts: RwLock<HashMap<ContractId, Contract>>,
     channels: RwLock<HashMap<ChannelId, Channel>>,
 }
@@ -48,6 +49,31 @@ impl Storage for MemoryStorage {
             .write()
             .unwrap()
             .merge(changeset.clone());
+        Ok(())
+    }
+
+    async fn load_labels(&self) -> Result<bip329::Labels, crate::error::WalletError> {
+        Ok(bip329::Labels::new(
+            self.labels.read().unwrap().values().cloned().collect(),
+        ))
+    }
+
+    async fn persist_label(&self, label: &bip329::Label) -> Result<(), crate::error::WalletError> {
+        self.labels
+            .write()
+            .unwrap()
+            .insert(super::label_key(&label.ref_()), label.clone());
+        Ok(())
+    }
+
+    async fn delete_label(
+        &self,
+        label_ref: &bip329::LabelRef,
+    ) -> Result<(), crate::error::WalletError> {
+        self.labels
+            .write()
+            .unwrap()
+            .remove(&super::label_key(label_ref));
         Ok(())
     }
 }
@@ -233,5 +259,58 @@ impl ddk_manager::Storage for MemoryStorage {
                 _ => None,
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::Hash;
+
+    #[tokio::test]
+    async fn labels_round_trip() {
+        let storage = MemoryStorage::new();
+        let txid = bitcoin::Txid::from_byte_array([0xAB; 32]);
+
+        let label = bip329::Label::Transaction(bip329::TransactionRecord {
+            ref_: txid,
+            label: Some("DLC funding".to_string()),
+            origin: None,
+        });
+        storage.persist_label(&label).await.unwrap();
+
+        // An input and an output record share the same outpoint
+        // reference and must not overwrite each other.
+        let outpoint = bitcoin::OutPoint { txid, vout: 0 };
+        let output_label = bip329::Label::Output(bip329::OutputRecord {
+            ref_: outpoint,
+            label: Some("collateral".to_string()),
+            spendable: Some(false),
+        });
+        let input_label = bip329::Label::Input(bip329::InputRecord {
+            ref_: outpoint,
+            label: Some("funding input".to_string()),
+        });
+        storage.persist_label(&output_label).await.unwrap();
+        storage.persist_label(&input_label).await.unwrap();
+
+        let labels = storage.load_labels().await.unwrap();
+        assert_eq!(labels.iter().count(), 3);
+
+        // Replacing by reference and deleting.
+        let renamed = bip329::Label::Transaction(bip329::TransactionRecord {
+            ref_: txid,
+            label: Some("DLC funding renamed".to_string()),
+            origin: None,
+        });
+        storage.persist_label(&renamed).await.unwrap();
+        storage.delete_label(&input_label.ref_()).await.unwrap();
+
+        let labels = storage.load_labels().await.unwrap();
+        assert_eq!(labels.iter().count(), 2);
+        assert!(labels.iter().any(|label| matches!(
+            label,
+            bip329::Label::Transaction(record) if record.label.as_deref() == Some("DLC funding renamed")
+        )));
     }
 }

--- a/ddk/src/storage/memory.rs
+++ b/ddk/src/storage/memory.rs
@@ -7,17 +7,14 @@ use std::sync::RwLock;
 #[derive(Default, Debug)]
 pub struct MemoryStorage {
     bdk_data: RwLock<Option<bdk_wallet::ChangeSet>>,
+    contract_tracker: RwLock<crate::wallet::contract_tracker::ChangeSet>,
     contracts: RwLock<HashMap<ContractId, Contract>>,
     channels: RwLock<HashMap<ChannelId, Channel>>,
 }
 
 impl MemoryStorage {
     pub fn new() -> Self {
-        Self {
-            bdk_data: RwLock::new(None),
-            contracts: RwLock::new(HashMap::new()),
-            channels: RwLock::new(HashMap::new()),
-        }
+        Self::default()
     }
 }
 
@@ -35,6 +32,23 @@ impl Storage for MemoryStorage {
 
     async fn initialize_bdk(&self) -> Result<bdk_wallet::ChangeSet, crate::error::WalletError> {
         Ok(self.bdk_data.read().unwrap().clone().unwrap_or_default())
+    }
+
+    async fn initialize_contract_tracker(
+        &self,
+    ) -> Result<crate::wallet::contract_tracker::ChangeSet, crate::error::WalletError> {
+        Ok(self.contract_tracker.read().unwrap().clone())
+    }
+
+    async fn persist_contract_tracker(
+        &self,
+        changeset: &crate::wallet::contract_tracker::ChangeSet,
+    ) -> Result<(), crate::error::WalletError> {
+        self.contract_tracker
+            .write()
+            .unwrap()
+            .merge(changeset.clone());
+        Ok(())
     }
 }
 

--- a/ddk/src/storage/mod.rs
+++ b/ddk/src/storage/mod.rs
@@ -6,3 +6,18 @@ pub mod sled;
 
 #[cfg(feature = "postgres")]
 pub mod sqlx;
+
+/// The storage key of a BIP-329 label: the record type tag plus the
+/// reference, because an input record and an output record can share the
+/// same outpoint reference.
+pub fn label_key(label_ref: &bip329::LabelRef) -> String {
+    use bip329::LabelRef;
+    match label_ref {
+        LabelRef::Txid(txid) => format!("tx:{txid}"),
+        LabelRef::Address(address) => format!("addr:{}", address.clone().assume_checked()),
+        LabelRef::PublicKey(pubkey) => format!("pubkey:{pubkey}"),
+        LabelRef::Input(outpoint) => format!("input:{outpoint}"),
+        LabelRef::Output(outpoint) => format!("output:{outpoint}"),
+        LabelRef::Xpub(xpub) => format!("xpub:{xpub}"),
+    }
+}

--- a/ddk/src/storage/postgres/migrations/0007_locked_outpoints.down.sql
+++ b/ddk/src/storage/postgres/migrations/0007_locked_outpoints.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS locked_outpoints;

--- a/ddk/src/storage/postgres/migrations/0007_locked_outpoints.up.sql
+++ b/ddk/src/storage/postgres/migrations/0007_locked_outpoints.up.sql
@@ -1,0 +1,11 @@
+-- BDK's changeset carries the wallet's locked outpoints (coins reserved for
+-- in-flight DLC offers). They were silently dropped on persist, so a lock
+-- did not survive a restart and a restarted wallet could select a reserved
+-- coin a second time.
+CREATE TABLE locked_outpoints (
+    wallet_name TEXT NOT NULL,
+    txid TEXT NOT NULL,
+    vout INTEGER NOT NULL,
+    is_locked BOOLEAN NOT NULL,
+    PRIMARY KEY (wallet_name, txid, vout)
+);

--- a/ddk/src/storage/postgres/migrations/0008_contract_tracker.down.sql
+++ b/ddk/src/storage/postgres/migrations/0008_contract_tracker.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS contract_tracker;

--- a/ddk/src/storage/postgres/migrations/0008_contract_tracker.up.sql
+++ b/ddk/src/storage/postgres/migrations/0008_contract_tracker.up.sql
@@ -1,0 +1,8 @@
+-- The contract UTXO tracker watches the 2-of-2 funding outputs beside the
+-- BDK wallet. Its changeset (funding script registrations and a transaction
+-- graph changeset) is serde-serializable and monotone under merge, so one
+-- merged JSONB document per wallet is enough.
+CREATE TABLE contract_tracker (
+    wallet_name TEXT PRIMARY KEY,
+    changeset JSONB NOT NULL
+);

--- a/ddk/src/storage/postgres/migrations/0009_wallet_labels.down.sql
+++ b/ddk/src/storage/postgres/migrations/0009_wallet_labels.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS wallet_labels;

--- a/ddk/src/storage/postgres/migrations/0009_wallet_labels.up.sql
+++ b/ddk/src/storage/postgres/migrations/0009_wallet_labels.up.sql
@@ -1,0 +1,9 @@
+-- BIP-329 wallet labels. The key is the record type tag plus the
+-- reference, because an input record and an output record can share the
+-- same outpoint reference.
+CREATE TABLE wallet_labels (
+    wallet_name TEXT NOT NULL,
+    label_key TEXT NOT NULL,
+    label JSONB NOT NULL,
+    PRIMARY KEY (wallet_name, label_key)
+);

--- a/ddk/src/storage/postgres/mod.rs
+++ b/ddk/src/storage/postgres/mod.rs
@@ -240,6 +240,7 @@ impl PostgresStore {
         changeset.tx_graph = tx_graph_changeset_from_postgres(tx, wallet_name).await?;
         changeset.local_chain = local_chain_changeset_from_postgres(tx, wallet_name).await?;
         changeset.indexer.spk_cache = spk_cache_from_postgres(tx, wallet_name).await?;
+        changeset.locked_outpoints = locked_outpoints_from_postgres(tx, wallet_name).await?;
         Ok(())
     }
 
@@ -299,6 +300,10 @@ impl PostgresStore {
             .await
             .map_err(StorageError::Sqlx)?;
         tx_graph_changeset_persist_to_postgres(&mut tx, wallet_name, &changeset.tx_graph)
+            .await
+            .map_err(StorageError::Sqlx)?;
+
+        locked_outpoints_persist_to_postgres(&mut tx, wallet_name, &changeset.locked_outpoints)
             .await
             .map_err(StorageError::Sqlx)?;
 
@@ -955,6 +960,62 @@ async fn tx_graph_changeset_persist_to_postgres(
     Ok(())
 }
 
+/// Select the wallet's locked outpoints.
+#[tracing::instrument(skip(db_tx))]
+async fn locked_outpoints_from_postgres(
+    db_tx: &mut Transaction<'_, Postgres>,
+    wallet_name: &str,
+) -> Result<bdk_wallet::locked_outpoints::ChangeSet, SqlxError> {
+    let rows =
+        sqlx::query("SELECT txid, vout, is_locked FROM locked_outpoints WHERE wallet_name = $1")
+            .bind(wallet_name)
+            .fetch_all(&mut **db_tx)
+            .await?;
+
+    let mut outpoints = BTreeMap::new();
+    for row in rows {
+        let txid: String = row.get("txid");
+        let vout: i32 = row.get("vout");
+        let is_locked: bool = row.get("is_locked");
+        let txid =
+            Txid::from_str(&txid).map_err(|_| SqlxError::Custom("parse locked txid".into()))?;
+        outpoints.insert(
+            OutPoint {
+                txid,
+                vout: vout as u32,
+            },
+            is_locked,
+        );
+    }
+
+    Ok(bdk_wallet::locked_outpoints::ChangeSet { outpoints })
+}
+
+/// Upsert the wallet's locked outpoints. A `false` overwrites an earlier
+/// `true`, matching the merge semantics of the BDK changeset.
+#[tracing::instrument(skip_all)]
+async fn locked_outpoints_persist_to_postgres(
+    db_tx: &mut Transaction<'_, Postgres>,
+    wallet_name: &str,
+    changeset: &bdk_wallet::locked_outpoints::ChangeSet,
+) -> Result<(), SqlxError> {
+    for (outpoint, is_locked) in &changeset.outpoints {
+        sqlx::query(
+            "INSERT INTO locked_outpoints (wallet_name, txid, vout, is_locked)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (wallet_name, txid, vout) DO UPDATE SET is_locked = $4",
+        )
+        .bind(wallet_name)
+        .bind(outpoint.txid.to_string())
+        .bind(outpoint.vout as i32)
+        .bind(is_locked)
+        .execute(&mut **db_tx)
+        .await?;
+    }
+
+    Ok(())
+}
+
 /// Select the cached script pubkeys of the keychain indexer.
 #[tracing::instrument(skip(db_tx))]
 async fn spk_cache_from_postgres(
@@ -1215,6 +1276,30 @@ mod tests {
         db.write(&advance).await.unwrap();
         let read = db.read().await.unwrap();
         assert_eq!(read.indexer.last_revealed.get(&did), Some(&9));
+    }
+
+    #[tokio::test]
+    async fn locked_outpoints_round_trip() {
+        let (_server, db) = seed_db().await;
+
+        let outpoint = OutPoint {
+            txid: dummy_tx().compute_txid(),
+            vout: 0,
+        };
+
+        let mut lock = ChangeSet::default();
+        lock.network = Some(Network::Regtest);
+        lock.locked_outpoints.outpoints.insert(outpoint, true);
+        db.write(&lock).await.unwrap();
+        let read = db.read().await.unwrap();
+        assert_eq!(read.locked_outpoints.outpoints.get(&outpoint), Some(&true));
+
+        // An unlock overwrites the lock.
+        let mut unlock = ChangeSet::default();
+        unlock.locked_outpoints.outpoints.insert(outpoint, false);
+        db.write(&unlock).await.unwrap();
+        let read = db.read().await.unwrap();
+        assert_eq!(read.locked_outpoints.outpoints.get(&outpoint), Some(&false));
     }
 
     #[tokio::test]

--- a/ddk/src/storage/postgres/mod.rs
+++ b/ddk/src/storage/postgres/mod.rs
@@ -333,6 +333,68 @@ impl Storage for PostgresStore {
             .await
             .map_err(|_| WalletError::StorageError("Did not persist bdk storage".to_string()))
     }
+
+    async fn initialize_contract_tracker(
+        &self,
+    ) -> Result<crate::wallet::contract_tracker::ChangeSet, WalletError> {
+        let row = sqlx::query("SELECT changeset FROM contract_tracker WHERE wallet_name = $1")
+            .bind(&self.wallet_name)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| WalletError::StorageError(e.to_string()))?;
+
+        match row {
+            Some(row) => {
+                let changeset: serde_json::Value = row.get("changeset");
+                Ok(serde_json::from_value(changeset)?)
+            }
+            None => Ok(crate::wallet::contract_tracker::ChangeSet::default()),
+        }
+    }
+
+    async fn persist_contract_tracker(
+        &self,
+        changeset: &crate::wallet::contract_tracker::ChangeSet,
+    ) -> Result<(), WalletError> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| WalletError::StorageError(e.to_string()))?;
+
+        // Merge with the stored changeset app-side; the changeset is
+        // monotone under merge.
+        let stored =
+            sqlx::query("SELECT changeset FROM contract_tracker WHERE wallet_name = $1 FOR UPDATE")
+                .bind(&self.wallet_name)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| WalletError::StorageError(e.to_string()))?;
+
+        let mut merged = match stored {
+            Some(row) => {
+                let value: serde_json::Value = row.get("changeset");
+                serde_json::from_value::<crate::wallet::contract_tracker::ChangeSet>(value)?
+            }
+            None => crate::wallet::contract_tracker::ChangeSet::default(),
+        };
+        merged.merge(changeset.clone());
+
+        sqlx::query(
+            "INSERT INTO contract_tracker (wallet_name, changeset) VALUES ($1, $2)
+             ON CONFLICT (wallet_name) DO UPDATE SET changeset = $2",
+        )
+        .bind(&self.wallet_name)
+        .bind(serde_json::to_value(&merged)?)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| WalletError::StorageError(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| WalletError::StorageError(e.to_string()))?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -1276,6 +1338,37 @@ mod tests {
         db.write(&advance).await.unwrap();
         let read = db.read().await.unwrap();
         assert_eq!(read.indexer.last_revealed.get(&did), Some(&9));
+    }
+
+    #[tokio::test]
+    async fn contract_tracker_round_trips() {
+        use crate::wallet::contract_tracker;
+        use crate::Storage as DdkStorage;
+
+        let (_server, db) = seed_db().await;
+
+        let spk = ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array([0xCD; 32]));
+        let mut changeset = contract_tracker::ChangeSet::default();
+        changeset.spks.insert([0x5A; 32], spk.clone());
+        changeset
+            .tx_graph
+            .last_seen
+            .insert(dummy_tx().compute_txid(), 100);
+        DdkStorage::persist_contract_tracker(&db, &changeset)
+            .await
+            .unwrap();
+        let read = DdkStorage::initialize_contract_tracker(&db).await.unwrap();
+        assert_eq!(read, changeset);
+
+        // A second persist merges instead of overwriting.
+        let mut more = contract_tracker::ChangeSet::default();
+        more.spks.insert([0x5B; 32], spk);
+        DdkStorage::persist_contract_tracker(&db, &more)
+            .await
+            .unwrap();
+        let read = DdkStorage::initialize_contract_tracker(&db).await.unwrap();
+        assert_eq!(read.spks.len(), 2);
+        assert_eq!(read.tx_graph.last_seen.len(), 1);
     }
 
     #[tokio::test]

--- a/ddk/src/storage/postgres/mod.rs
+++ b/ddk/src/storage/postgres/mod.rs
@@ -395,6 +395,47 @@ impl Storage for PostgresStore {
             .map_err(|e| WalletError::StorageError(e.to_string()))?;
         Ok(())
     }
+
+    async fn load_labels(&self) -> Result<bip329::Labels, WalletError> {
+        let rows = sqlx::query("SELECT label FROM wallet_labels WHERE wallet_name = $1")
+            .bind(&self.wallet_name)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| WalletError::StorageError(e.to_string()))?;
+
+        let labels = rows
+            .into_iter()
+            .map(|row| {
+                let label: serde_json::Value = row.get("label");
+                Ok(serde_json::from_value::<bip329::Label>(label)?)
+            })
+            .collect::<Result<Vec<_>, WalletError>>()?;
+        Ok(bip329::Labels::new(labels))
+    }
+
+    async fn persist_label(&self, label: &bip329::Label) -> Result<(), WalletError> {
+        sqlx::query(
+            "INSERT INTO wallet_labels (wallet_name, label_key, label) VALUES ($1, $2, $3)
+             ON CONFLICT (wallet_name, label_key) DO UPDATE SET label = $3",
+        )
+        .bind(&self.wallet_name)
+        .bind(crate::storage::label_key(&label.ref_()))
+        .bind(serde_json::to_value(label)?)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| WalletError::StorageError(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn delete_label(&self, label_ref: &bip329::LabelRef) -> Result<(), WalletError> {
+        sqlx::query("DELETE FROM wallet_labels WHERE wallet_name = $1 AND label_key = $2")
+            .bind(&self.wallet_name)
+            .bind(crate::storage::label_key(label_ref))
+            .execute(&self.pool)
+            .await
+            .map_err(|e| WalletError::StorageError(e.to_string()))?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -1338,6 +1379,49 @@ mod tests {
         db.write(&advance).await.unwrap();
         let read = db.read().await.unwrap();
         assert_eq!(read.indexer.last_revealed.get(&did), Some(&9));
+    }
+
+    #[tokio::test]
+    async fn labels_round_trip() {
+        use crate::Storage as DdkStorage;
+
+        let (_server, db) = seed_db().await;
+        let txid = dummy_tx().compute_txid();
+
+        let label = bip329::Label::Transaction(bip329::TransactionRecord {
+            ref_: txid,
+            label: Some("DLC funding".to_string()),
+            origin: None,
+        });
+        DdkStorage::persist_label(&db, &label).await.unwrap();
+
+        let output_label = bip329::Label::Output(bip329::OutputRecord {
+            ref_: OutPoint { txid, vout: 0 },
+            label: Some("collateral".to_string()),
+            spendable: Some(false),
+        });
+        DdkStorage::persist_label(&db, &output_label).await.unwrap();
+
+        let labels = DdkStorage::load_labels(&db).await.unwrap();
+        assert_eq!(labels.iter().count(), 2);
+
+        // Replacing by reference and deleting.
+        let renamed = bip329::Label::Transaction(bip329::TransactionRecord {
+            ref_: txid,
+            label: Some("renamed".to_string()),
+            origin: None,
+        });
+        DdkStorage::persist_label(&db, &renamed).await.unwrap();
+        DdkStorage::delete_label(&db, &output_label.ref_())
+            .await
+            .unwrap();
+
+        let labels = DdkStorage::load_labels(&db).await.unwrap();
+        assert_eq!(labels.iter().count(), 1);
+        assert!(labels.iter().any(|label| matches!(
+            label,
+            bip329::Label::Transaction(record) if record.label.as_deref() == Some("renamed")
+        )));
     }
 
     #[tokio::test]

--- a/ddk/src/storage/sled/mod.rs
+++ b/ddk/src/storage/sled/mod.rs
@@ -134,3 +134,37 @@ impl Storage for SledStorage {
 fn sled_to_wallet_error(error: sled::Error) -> WalletError {
     WalletError::StorageError(error.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::Hash;
+    use bitcoin::{OutPoint, Txid};
+
+    #[tokio::test]
+    async fn locked_outpoints_round_trip() {
+        let path = "tests/data/dlc_storagedb/locked_outpoints_round_trip";
+        let logger = Arc::new(Logger::disabled("sled_test".to_string()));
+        {
+            let storage = SledStorage::new(path, logger).expect("Error opening sled DB");
+            let outpoint = OutPoint {
+                txid: Txid::from_byte_array([0xAB; 32]),
+                vout: 1,
+            };
+
+            let mut lock = ChangeSet::default();
+            lock.locked_outpoints.outpoints.insert(outpoint, true);
+            storage.persist_bdk(&lock).await.unwrap();
+            let read = storage.initialize_bdk().await.unwrap();
+            assert_eq!(read.locked_outpoints.outpoints.get(&outpoint), Some(&true));
+
+            // An unlock overwrites the lock.
+            let mut unlock = ChangeSet::default();
+            unlock.locked_outpoints.outpoints.insert(outpoint, false);
+            storage.persist_bdk(&unlock).await.unwrap();
+            let read = storage.initialize_bdk().await.unwrap();
+            assert_eq!(read.locked_outpoints.outpoints.get(&outpoint), Some(&false));
+        }
+        std::fs::remove_dir_all(path).unwrap();
+    }
+}

--- a/ddk/src/storage/sled/mod.rs
+++ b/ddk/src/storage/sled/mod.rs
@@ -24,6 +24,7 @@ pub const CHAIN_MONITOR_KEY: u8 = 4;
 const SIGNER_TREE: u8 = 6;
 const WALLET_TREE: u8 = 7;
 const MARKETPLACE_TREE: u8 = 8;
+const LABEL_TREE: u8 = 9;
 const CHANGESET_KEY: &str = "changeset";
 const CONTRACT_TRACKER_KEY: &str = "contract_tracker";
 
@@ -92,6 +93,10 @@ impl SledStorage {
 
     pub fn marketplace_tree(&self) -> Result<Tree, sled::Error> {
         self.db.open_tree([MARKETPLACE_TREE])
+    }
+
+    fn label_tree(&self) -> Result<Tree, sled::Error> {
+        self.db.open_tree([LABEL_TREE])
     }
 }
 
@@ -169,6 +174,39 @@ impl Storage for SledStorage {
             .map_err(sled_to_wallet_error)?;
         Ok(())
     }
+
+    async fn load_labels(&self) -> Result<bip329::Labels, WalletError> {
+        let labels = self
+            .label_tree()
+            .map_err(sled_to_wallet_error)?
+            .iter()
+            .values()
+            .map(|value| {
+                let value = value.map_err(sled_to_wallet_error)?;
+                Ok(serde_json::from_slice::<bip329::Label>(&value)?)
+            })
+            .collect::<Result<Vec<_>, WalletError>>()?;
+        Ok(bip329::Labels::new(labels))
+    }
+
+    async fn persist_label(&self, label: &bip329::Label) -> Result<(), WalletError> {
+        self.label_tree()
+            .map_err(sled_to_wallet_error)?
+            .insert(
+                crate::storage::label_key(&label.ref_()).as_bytes(),
+                serde_json::to_vec(label)?,
+            )
+            .map_err(sled_to_wallet_error)?;
+        Ok(())
+    }
+
+    async fn delete_label(&self, label_ref: &bip329::LabelRef) -> Result<(), WalletError> {
+        self.label_tree()
+            .map_err(sled_to_wallet_error)?
+            .remove(crate::storage::label_key(label_ref).as_bytes())
+            .map_err(sled_to_wallet_error)?;
+        Ok(())
+    }
 }
 
 fn sled_to_wallet_error(error: sled::Error) -> WalletError {
@@ -180,6 +218,38 @@ mod tests {
     use super::*;
     use bitcoin::hashes::Hash;
     use bitcoin::{OutPoint, Txid};
+
+    #[tokio::test]
+    async fn labels_round_trip() {
+        let path = "tests/data/dlc_storagedb/labels_round_trip";
+        let logger = Arc::new(Logger::disabled("sled_test".to_string()));
+        {
+            let storage = SledStorage::new(path, logger).expect("Error opening sled DB");
+            let txid = Txid::from_byte_array([0xAB; 32]);
+
+            let label = bip329::Label::Transaction(bip329::TransactionRecord {
+                ref_: txid,
+                label: Some("DLC funding".to_string()),
+                origin: None,
+            });
+            storage.persist_label(&label).await.unwrap();
+
+            let output_label = bip329::Label::Output(bip329::OutputRecord {
+                ref_: OutPoint { txid, vout: 0 },
+                label: Some("collateral".to_string()),
+                spendable: Some(false),
+            });
+            storage.persist_label(&output_label).await.unwrap();
+
+            let labels = storage.load_labels().await.unwrap();
+            assert_eq!(labels.iter().count(), 2);
+
+            storage.delete_label(&label.ref_()).await.unwrap();
+            let labels = storage.load_labels().await.unwrap();
+            assert_eq!(labels.iter().count(), 1);
+        }
+        std::fs::remove_dir_all(path).unwrap();
+    }
 
     #[tokio::test]
     async fn contract_tracker_round_trips() {

--- a/ddk/src/storage/sled/mod.rs
+++ b/ddk/src/storage/sled/mod.rs
@@ -25,6 +25,7 @@ const SIGNER_TREE: u8 = 6;
 const WALLET_TREE: u8 = 7;
 const MARKETPLACE_TREE: u8 = 8;
 const CHANGESET_KEY: &str = "changeset";
+const CONTRACT_TRACKER_KEY: &str = "contract_tracker";
 
 /// Implementation of Storage interface using the sled DB backend.
 #[derive(Debug, Clone)]
@@ -129,6 +130,45 @@ impl Storage for SledStorage {
         };
         Ok(changeset)
     }
+
+    async fn initialize_contract_tracker(
+        &self,
+    ) -> Result<crate::wallet::contract_tracker::ChangeSet, WalletError> {
+        let changeset = match self
+            .wallet_tree()
+            .map_err(sled_to_wallet_error)?
+            .get(CONTRACT_TRACKER_KEY)
+            .map_err(sled_to_wallet_error)?
+        {
+            Some(changeset) => serde_json::from_slice(&changeset)?,
+            None => crate::wallet::contract_tracker::ChangeSet::default(),
+        };
+        Ok(changeset)
+    }
+
+    async fn persist_contract_tracker(
+        &self,
+        changeset: &crate::wallet::contract_tracker::ChangeSet,
+    ) -> Result<(), WalletError> {
+        let wallet_tree = self.wallet_tree().map_err(sled_to_wallet_error)?;
+        let new_changeset = match wallet_tree
+            .get(CONTRACT_TRACKER_KEY)
+            .map_err(sled_to_wallet_error)?
+        {
+            Some(stored) => {
+                let mut stored =
+                    serde_json::from_slice::<crate::wallet::contract_tracker::ChangeSet>(&stored)?;
+                stored.merge(changeset.clone());
+                stored
+            }
+            None => changeset.to_owned(),
+        };
+
+        wallet_tree
+            .insert(CONTRACT_TRACKER_KEY, serde_json::to_vec(&new_changeset)?)
+            .map_err(sled_to_wallet_error)?;
+        Ok(())
+    }
 }
 
 fn sled_to_wallet_error(error: sled::Error) -> WalletError {
@@ -140,6 +180,38 @@ mod tests {
     use super::*;
     use bitcoin::hashes::Hash;
     use bitcoin::{OutPoint, Txid};
+
+    #[tokio::test]
+    async fn contract_tracker_round_trips() {
+        use crate::wallet::contract_tracker;
+
+        let path = "tests/data/dlc_storagedb/contract_tracker_round_trips";
+        let logger = Arc::new(Logger::disabled("sled_test".to_string()));
+        {
+            let storage = SledStorage::new(path, logger).expect("Error opening sled DB");
+
+            let spk =
+                bitcoin::ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array([0xCD; 32]));
+            let mut changeset = contract_tracker::ChangeSet::default();
+            changeset.spks.insert([0x5A; 32], spk.clone());
+            changeset
+                .tx_graph
+                .last_seen
+                .insert(Txid::from_byte_array([0xAB; 32]), 100);
+            storage.persist_contract_tracker(&changeset).await.unwrap();
+            let read = storage.initialize_contract_tracker().await.unwrap();
+            assert_eq!(read, changeset);
+
+            // A second persist merges instead of overwriting.
+            let mut more = contract_tracker::ChangeSet::default();
+            more.spks.insert([0x5B; 32], spk);
+            storage.persist_contract_tracker(&more).await.unwrap();
+            let read = storage.initialize_contract_tracker().await.unwrap();
+            assert_eq!(read.spks.len(), 2);
+            assert_eq!(read.tx_graph.last_seen.len(), 1);
+        }
+        std::fs::remove_dir_all(path).unwrap();
+    }
 
     #[tokio::test]
     async fn locked_outpoints_round_trip() {

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -403,6 +403,7 @@ pub async fn select_utxos(
     amount: Amount,
     fee_rate: u64,
     lock_utxos: bool,
+    min_change_size: u64,
 ) -> Result<Vec<ddk_manager::Utxo>> {
     let candidates = wallet
         .list_unspent()
@@ -416,7 +417,7 @@ pub async fn select_utxos(
     let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
         .ok_or_else(|| WalletError::Esplora(format!("Invalid fee rate: {fee_rate}")))?;
 
-    let selected = BranchAndBoundCoinSelection::new(super::MIN_CHANGE_SIZE, SingleRandomDraw)
+    let selected = BranchAndBoundCoinSelection::new(min_change_size, SingleRandomDraw)
         .coin_select(
             vec![],
             candidates,

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -222,6 +222,53 @@ pub(super) fn contract_funding_spk(contract: &Contract) -> Option<(ContractId, S
     ))
 }
 
+/// What a send spends: a specific amount, or the whole wallet.
+#[derive(Debug)]
+pub enum Spend {
+    /// Send this amount to the destination
+    Amount(Amount),
+    /// Drain every spendable coin to the destination
+    All,
+}
+
+/// Builds, signs, and broadcasts a spend to `address`, then persists the
+/// wallet so the revealed change index survives a restart.
+#[tracing::instrument(skip(wallet, blockchain, storage))]
+pub async fn send(
+    wallet: &mut PersistedWallet<WalletStorage>,
+    blockchain: &EsploraClient,
+    storage: &mut WalletStorage,
+    address: Address,
+    spend: Spend,
+    fee_rate: FeeRate,
+) -> Result<bitcoin::Txid> {
+    let mut builder = wallet.build_tx();
+    builder.version(2).fee_rate(fee_rate);
+    match spend {
+        Spend::Amount(amount) => {
+            builder.add_recipient(address.script_pubkey(), amount);
+        }
+        Spend::All => {
+            builder.drain_wallet();
+            builder.drain_to(address.script_pubkey());
+        }
+    }
+    let mut psbt = builder.finish()?;
+    wallet.sign(&mut psbt, bdk_wallet::SignOptions::default())?;
+    let tx = psbt.extract_tx().map_err(|_| WalletError::ExtractTx)?;
+    let txid = tx.compute_txid();
+    blockchain
+        .async_client
+        .broadcast(&tx)
+        .await
+        .map_err(|e| WalletError::Esplora(e.to_string()))?;
+    wallet
+        .persist_async(storage)
+        .await
+        .map_err(|e| WalletError::WalletPersistanceError(e.to_string()))?;
+    Ok(txid)
+}
+
 /// Selects UTXOs that cover `amount` at `fee_rate`, ignoring locked
 /// outpoints. When `lock_utxos` is set, the selected outpoints are locked and
 /// the locks are persisted, so a concurrent selection cannot pick the same

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -88,6 +88,31 @@ pub async fn sync(
         Update::from(sync)
     };
     wallet.apply_update(sync_result)?;
+
+    // A lock on an outpoint that a confirmed transaction spent is dead
+    // weight: release it. Unconfirmed spends keep their locks, because an
+    // evicted transaction would return the coin to the spendable set.
+    let confirmed_spends = wallet
+        .transactions()
+        .filter(|canonical_tx| canonical_tx.chain_position.is_confirmed())
+        .flat_map(|canonical_tx| {
+            canonical_tx
+                .tx_node
+                .tx
+                .input
+                .iter()
+                .map(|input| input.previous_output)
+                .collect::<Vec<_>>()
+        })
+        .collect::<std::collections::HashSet<_>>();
+    let spent_locks = wallet
+        .list_locked_outpoints()
+        .filter(|outpoint| confirmed_spends.contains(outpoint))
+        .collect::<Vec<_>>();
+    for outpoint in spent_locks {
+        wallet.unlock_outpoint(outpoint);
+    }
+
     wallet
         .persist_async(storage)
         .await

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -1,8 +1,9 @@
+use super::contract_tracker::ContractUtxoTracker;
 use super::WalletStorage;
 use crate::error::WalletError;
-use crate::logger::{log_debug, WriteLog};
+use crate::logger::{log_debug, log_error, WriteLog};
 use crate::{chain::EsploraClient, logger::Logger};
-use bdk_chain::spk_client::FullScanRequest;
+use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
 use bdk_esplora::EsploraAsyncExt;
 use bdk_wallet::coin_selection::{
     BranchAndBoundCoinSelection, CoinSelectionAlgorithm, SingleRandomDraw,
@@ -10,6 +11,8 @@ use bdk_wallet::coin_selection::{
 use bdk_wallet::{KeychainKind, PersistedWallet, Update, Utxo, WeightedUtxo};
 use bitcoin::key::rand::thread_rng;
 use bitcoin::{Address, Amount, FeeRate, ScriptBuf};
+use ddk_manager::contract::Contract;
+use ddk_manager::ContractId;
 use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, WalletError>;
@@ -23,6 +26,7 @@ const PARALLEL_REQUESTS: usize = 5;
 #[tracing::instrument(skip_all)]
 pub async fn sync(
     wallet: &mut PersistedWallet<WalletStorage>,
+    tracker: &mut ContractUtxoTracker,
     blockchain: &EsploraClient,
     storage: &mut WalletStorage,
     logger: Arc<Logger>,
@@ -113,11 +117,88 @@ pub async fn sync(
         wallet.unlock_outpoint(outpoint);
     }
 
+    sync_contract_utxos(wallet, tracker, blockchain, storage, logger).await?;
+
     wallet
         .persist_async(storage)
         .await
         .map_err(|e| WalletError::WalletPersistanceError(e.to_string()))?;
     Ok(())
+}
+
+/// Runs a second, targeted sync over the contract funding SPKs and
+/// outpoints. Esplora resolves outpoint spend status, so one round trip
+/// learns both confirmation of the funding transaction and any spend of the
+/// funding output (CET, refund, or counterparty close).
+async fn sync_contract_utxos(
+    wallet: &mut PersistedWallet<WalletStorage>,
+    tracker: &mut ContractUtxoTracker,
+    blockchain: &EsploraClient,
+    storage: &mut WalletStorage,
+    logger: Arc<Logger>,
+) -> Result<()> {
+    // Contracts learn their funding transaction at accept time; register
+    // every funding script the storage knows about.
+    match storage.0.get_contracts().await {
+        Ok(contracts) => {
+            for contract in &contracts {
+                if let Some((contract_id, spk)) = contract_funding_spk(contract) {
+                    tracker.register(contract_id, spk);
+                }
+            }
+        }
+        Err(e) => log_error!(
+            logger,
+            "Could not load contracts for the funding tracker. error={}",
+            e
+        ),
+    }
+
+    let spks = tracker.sync_spks();
+    if spks.is_empty() {
+        return Ok(());
+    }
+
+    let request = SyncRequest::builder()
+        .chain_tip(wallet.latest_checkpoint())
+        .spks(spks)
+        .outpoints(tracker.sync_outpoints())
+        .build();
+    let response = blockchain
+        .async_client
+        .sync(request, PARALLEL_REQUESTS)
+        .await
+        .map_err(|e| WalletError::Esplora(e.to_string()))?;
+
+    // The tracker shares the wallet's chain view: connect the chain update
+    // to the wallet so the tracker's anchors resolve.
+    if let Some(chain_update) = response.chain_update {
+        wallet.apply_update(Update {
+            chain: Some(chain_update),
+            ..Default::default()
+        })?;
+    }
+    tracker.apply_update(response.tx_update);
+
+    Ok(())
+}
+
+/// The funding script of a contract that has a funding transaction, with
+/// the contract's id. Offered contracts do not have one yet: the funding
+/// transaction needs the accept party's inputs.
+pub(super) fn contract_funding_spk(contract: &Contract) -> Option<(ContractId, ScriptBuf)> {
+    let accepted = match contract {
+        Contract::Accepted(accepted) => accepted,
+        Contract::Signed(signed) | Contract::Confirmed(signed) => &signed.accepted_contract,
+        Contract::PreClosed(preclosed) => &preclosed.signed_contract.accepted_contract,
+        _ => return None,
+    };
+    let transactions = &accepted.dlc_transactions;
+    let fund_output = transactions.get_fund_output();
+    Some((
+        accepted.get_contract_id(),
+        fund_output.script_pubkey.clone(),
+    ))
 }
 
 /// Selects UTXOs that cover `amount` at `fee_rate`, ignoring locked
@@ -182,4 +263,39 @@ pub async fn select_utxos(
     }
 
     Ok(utxos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::ser::deserialize_contract;
+
+    #[test]
+    fn funding_spk_follows_the_contract_state() {
+        let offered = deserialize_contract(
+            &include_bytes!("../../../testconfig/contract_binaries/Offered").to_vec(),
+        )
+        .unwrap();
+        assert!(contract_funding_spk(&offered).is_none());
+
+        let accepted = deserialize_contract(
+            &include_bytes!("../../../testconfig/contract_binaries/Accepted").to_vec(),
+        )
+        .unwrap();
+        let (accepted_id, accepted_spk) = contract_funding_spk(&accepted).unwrap();
+        assert!(accepted_spk.is_p2wsh());
+
+        // The same contract keeps the same funding script through its
+        // lifecycle.
+        for binary in [
+            include_bytes!("../../../testconfig/contract_binaries/Signed").to_vec(),
+            include_bytes!("../../../testconfig/contract_binaries/Confirmed").to_vec(),
+            include_bytes!("../../../testconfig/contract_binaries/PreClosed").to_vec(),
+        ] {
+            let contract = deserialize_contract(&binary).unwrap();
+            let (contract_id, spk) = contract_funding_spk(&contract).unwrap();
+            assert_eq!(contract_id, accepted_id);
+            assert_eq!(spk, accepted_spk);
+        }
+    }
 }

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -305,6 +305,17 @@ pub enum Spend {
     All,
 }
 
+/// Coin control for a send: restrict which UTXOs fund the transaction.
+#[derive(Debug, Default, Clone)]
+pub struct CoinControl {
+    /// Fund the transaction with exactly these UTXOs and no others
+    pub selected_utxos: Vec<bitcoin::OutPoint>,
+    /// Never spend these outpoints
+    pub unspendable: Vec<bitcoin::OutPoint>,
+    /// Only spend coins with at least this many confirmations
+    pub min_confirmations: Option<u32>,
+}
+
 /// Builds, signs, and broadcasts a spend to `address`, then persists the
 /// wallet so the revealed change index survives a restart.
 #[tracing::instrument(skip(wallet, blockchain, storage))]
@@ -315,6 +326,7 @@ pub async fn send(
     address: Address,
     spend: Spend,
     fee_rate: FeeRate,
+    coin_control: CoinControl,
 ) -> Result<bitcoin::Txid> {
     let mut builder = wallet.build_tx();
     builder.version(2).fee_rate(fee_rate);
@@ -323,9 +335,19 @@ pub async fn send(
             builder.add_recipient(address.script_pubkey(), amount);
         }
         Spend::All => {
-            builder.drain_wallet();
+            if coin_control.selected_utxos.is_empty() {
+                builder.drain_wallet();
+            }
             builder.drain_to(address.script_pubkey());
         }
+    }
+    if !coin_control.selected_utxos.is_empty() {
+        builder.add_utxos(&coin_control.selected_utxos)?;
+        builder.manually_selected_only();
+    }
+    builder.unspendable(coin_control.unspendable);
+    if let Some(min_confirmations) = coin_control.min_confirmations {
+        builder.exclude_below_confirmations(min_confirmations);
     }
     let mut psbt = builder.finish()?;
     wallet.sign(&mut psbt, bdk_wallet::SignOptions::default())?;

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -8,12 +8,13 @@ use bdk_esplora::EsploraAsyncExt;
 use bdk_wallet::coin_selection::{
     BranchAndBoundCoinSelection, CoinSelectionAlgorithm, SingleRandomDraw,
 };
-use bdk_wallet::{KeychainKind, PersistedWallet, Update, Utxo, WeightedUtxo};
+use bdk_wallet::{KeychainKind, PersistedWallet, Update, Utxo, WalletEvent, WeightedUtxo};
 use bitcoin::key::rand::thread_rng;
 use bitcoin::{Address, Amount, FeeRate, ScriptBuf};
 use ddk_manager::contract::Contract;
 use ddk_manager::ContractId;
 use std::sync::Arc;
+use tokio::sync::broadcast;
 
 type Result<T> = std::result::Result<T, WalletError>;
 
@@ -29,6 +30,7 @@ pub async fn sync(
     tracker: &mut ContractUtxoTracker,
     blockchain: &EsploraClient,
     storage: &mut WalletStorage,
+    events: &broadcast::Sender<WalletEvent>,
     logger: Arc<Logger>,
 ) -> Result<()> {
     let block_height = blockchain
@@ -91,7 +93,7 @@ pub async fn sync(
             .map_err(|e| WalletError::Esplora(e.to_string()))?;
         Update::from(sync)
     };
-    wallet.apply_update(sync_result)?;
+    forward_events(events, wallet.apply_update_events(sync_result)?);
 
     // A lock on an outpoint that a confirmed transaction spent is dead
     // weight: release it. Unconfirmed spends keep their locks, because an
@@ -117,7 +119,7 @@ pub async fn sync(
         wallet.unlock_outpoint(outpoint);
     }
 
-    sync_contract_utxos(wallet, tracker, blockchain, storage, logger).await?;
+    sync_contract_utxos(wallet, tracker, blockchain, storage, events, logger).await?;
 
     wallet
         .persist_async(storage)
@@ -138,6 +140,7 @@ async fn sync_contract_utxos(
     tracker: &mut ContractUtxoTracker,
     blockchain: &EsploraClient,
     storage: &mut WalletStorage,
+    events: &broadcast::Sender<WalletEvent>,
     logger: Arc<Logger>,
 ) -> Result<()> {
     // Contracts learn their funding transaction at accept time; register
@@ -176,14 +179,25 @@ async fn sync_contract_utxos(
     // The tracker shares the wallet's chain view: connect the chain update
     // to the wallet so the tracker's anchors resolve.
     if let Some(chain_update) = response.chain_update {
-        wallet.apply_update(Update {
-            chain: Some(chain_update),
-            ..Default::default()
-        })?;
+        forward_events(
+            events,
+            wallet.apply_update_events(Update {
+                chain: Some(chain_update),
+                ..Default::default()
+            })?,
+        );
     }
     tracker.apply_update(response.tx_update);
 
     Ok(())
+}
+
+/// Forwards wallet events to the subscribers. A send fails only when no
+/// subscriber exists, which is fine.
+fn forward_events(events: &broadcast::Sender<WalletEvent>, wallet_events: Vec<WalletEvent>) {
+    for event in wallet_events {
+        let _ = events.send(event);
+    }
 }
 
 /// The funding script of a contract that has a funding transaction, with

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -148,12 +148,43 @@ async fn sync_contract_utxos(
     logger: Arc<Logger>,
 ) -> Result<()> {
     // Contracts learn their funding transaction at accept time; register
-    // every funding script the storage knows about.
+    // every funding script the storage knows about. Registration and a
+    // close also write BIP-329 labels: the funding transaction and its
+    // outpoint get the contract id, the CET gets the attested outcome.
+    // Label writes are upserts, so repeating them is harmless, and a
+    // failed write never fails the sync.
     match storage.0.get_contracts().await {
         Ok(contracts) => {
             for contract in &contracts {
-                if let Some((contract_id, spk)) = contract_funding_spk(contract) {
-                    tracker.register(contract_id, spk);
+                if let Some((contract_id, spk, outpoint)) = contract_funding_info(contract) {
+                    if tracker.register(contract_id, spk) {
+                        let funding_tx_label =
+                            bip329::Label::Transaction(bip329::TransactionRecord {
+                                ref_: outpoint.txid,
+                                label: Some(format!("DLC funding {}", hex::encode(contract_id))),
+                                origin: None,
+                            });
+                        let funding_output_label = bip329::Label::Output(bip329::OutputRecord {
+                            ref_: outpoint,
+                            label: Some(hex::encode(contract_id)),
+                            spendable: Some(false),
+                        });
+                        for label in [funding_tx_label, funding_output_label] {
+                            if let Err(e) = storage.0.persist_label(&label).await {
+                                log_error!(logger, "Could not write a contract label. error={}", e);
+                            }
+                        }
+                    }
+                }
+                if let Some((cet_txid, close_label)) = contract_close_label(contract) {
+                    let label = bip329::Label::Transaction(bip329::TransactionRecord {
+                        ref_: cet_txid,
+                        label: Some(close_label),
+                        origin: None,
+                    });
+                    if let Err(e) = storage.0.persist_label(&label).await {
+                        log_error!(logger, "Could not write a close label. error={}", e);
+                    }
                 }
             }
         }
@@ -204,10 +235,12 @@ fn forward_events(events: &broadcast::Sender<WalletEvent>, wallet_events: Vec<Wa
     }
 }
 
-/// The funding script of a contract that has a funding transaction, with
-/// the contract's id. Offered contracts do not have one yet: the funding
-/// transaction needs the accept party's inputs.
-pub(super) fn contract_funding_spk(contract: &Contract) -> Option<(ContractId, ScriptBuf)> {
+/// The funding script and outpoint of a contract that has a funding
+/// transaction, with the contract's id. Offered contracts do not have one
+/// yet: the funding transaction needs the accept party's inputs.
+pub(super) fn contract_funding_info(
+    contract: &Contract,
+) -> Option<(ContractId, ScriptBuf, bitcoin::OutPoint)> {
     let accepted = match contract {
         Contract::Accepted(accepted) => accepted,
         Contract::Signed(signed) | Contract::Confirmed(signed) => &signed.accepted_contract,
@@ -216,10 +249,51 @@ pub(super) fn contract_funding_spk(contract: &Contract) -> Option<(ContractId, S
     };
     let transactions = &accepted.dlc_transactions;
     let fund_output = transactions.get_fund_output();
+    let outpoint = bitcoin::OutPoint {
+        txid: transactions.fund.compute_txid(),
+        vout: transactions.get_fund_output_index() as u32,
+    };
     Some((
         accepted.get_contract_id(),
         fund_output.script_pubkey.clone(),
+        outpoint,
     ))
+}
+
+/// The broadcast CET of a closed or pre-closed contract with the label it
+/// gets: the contract id and the attested outcome.
+pub(super) fn contract_close_label(contract: &Contract) -> Option<(bitcoin::Txid, String)> {
+    let (cet, attestations, contract_id) = match contract {
+        Contract::PreClosed(preclosed) => (
+            Some(&preclosed.signed_cet),
+            preclosed.attestations.as_ref(),
+            preclosed
+                .signed_contract
+                .accepted_contract
+                .get_contract_id(),
+        ),
+        Contract::Closed(closed) => (
+            closed.signed_cet.as_ref(),
+            closed.attestations.as_ref(),
+            closed.contract_id,
+        ),
+        _ => return None,
+    };
+    let txid = cet?.compute_txid();
+    let outcomes = attestations
+        .map(|attestations| {
+            attestations
+                .iter()
+                .flat_map(|attestation| attestation.outcomes.clone())
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .filter(|outcomes| !outcomes.is_empty());
+    let label = match outcomes {
+        Some(outcomes) => format!("DLC close {}: {}", hex::encode(contract_id), outcomes),
+        None => format!("DLC close {}", hex::encode(contract_id)),
+    };
+    Some((txid, label))
 }
 
 /// What a send spends: a specific amount, or the whole wallet.
@@ -344,13 +418,14 @@ mod tests {
             &include_bytes!("../../../testconfig/contract_binaries/Offered").to_vec(),
         )
         .unwrap();
-        assert!(contract_funding_spk(&offered).is_none());
+        assert!(contract_funding_info(&offered).is_none());
 
         let accepted = deserialize_contract(
             &include_bytes!("../../../testconfig/contract_binaries/Accepted").to_vec(),
         )
         .unwrap();
-        let (accepted_id, accepted_spk) = contract_funding_spk(&accepted).unwrap();
+        let (accepted_id, accepted_spk, accepted_outpoint) =
+            contract_funding_info(&accepted).unwrap();
         assert!(accepted_spk.is_p2wsh());
 
         // The same contract keeps the same funding script through its
@@ -361,9 +436,28 @@ mod tests {
             include_bytes!("../../../testconfig/contract_binaries/PreClosed").to_vec(),
         ] {
             let contract = deserialize_contract(&binary).unwrap();
-            let (contract_id, spk) = contract_funding_spk(&contract).unwrap();
+            let (contract_id, spk, outpoint) = contract_funding_info(&contract).unwrap();
             assert_eq!(contract_id, accepted_id);
             assert_eq!(spk, accepted_spk);
+            assert_eq!(outpoint, accepted_outpoint);
+        }
+    }
+
+    #[test]
+    fn close_labels_carry_the_outcome() {
+        let confirmed = deserialize_contract(
+            &include_bytes!("../../../testconfig/contract_binaries/Confirmed").to_vec(),
+        )
+        .unwrap();
+        assert!(contract_close_label(&confirmed).is_none());
+
+        for binary in [
+            include_bytes!("../../../testconfig/contract_binaries/PreClosed").to_vec(),
+            include_bytes!("../../../testconfig/contract_binaries/Closed").to_vec(),
+        ] {
+            let contract = deserialize_contract(&binary).unwrap();
+            let (_txid, label) = contract_close_label(&contract).unwrap();
+            assert!(label.starts_with("DLC close "));
         }
     }
 }

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -61,8 +61,21 @@ pub async fn sync(
             chain: sync.chain_update,
         }
     } else {
+        // Tell esplora which txids we expect under our SPKs. Expected txids
+        // that no longer show up come back stamped as evicted, which drops
+        // replaced or evicted transactions from the canonical view.
+        let expected_spk_txids = wallet
+            .tx_graph()
+            .list_expected_spk_txids(
+                wallet.local_chain(),
+                prev_tip.block_id(),
+                wallet.spk_index(),
+                ..,
+            )
+            .collect::<Vec<_>>();
         let spks = wallet
             .start_sync_with_revealed_spks()
+            .expected_spk_txids(expected_spk_txids)
             .chain_tip(prev_tip)
             .build();
         let sync = blockchain

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -123,6 +123,9 @@ pub async fn sync(
         .persist_async(storage)
         .await
         .map_err(|e| WalletError::WalletPersistanceError(e.to_string()))?;
+    if let Some(changeset) = tracker.take_staged() {
+        storage.0.persist_contract_tracker(&changeset).await?;
+    }
     Ok(())
 }
 

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -10,6 +10,12 @@ use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, WalletError>;
 
+/// The number of consecutive unused script pubkeys to scan before a full scan
+/// stops. A restored wallet with gaps larger than this does not find all funds.
+const STOP_GAP: usize = 50;
+/// The number of esplora requests a scan makes in parallel.
+const PARALLEL_REQUESTS: usize = 5;
+
 #[tracing::instrument(skip_all)]
 pub async fn sync(
     wallet: &mut PersistedWallet<WalletStorage>,
@@ -36,18 +42,21 @@ pub async fn sync(
     );
     let sync_result = if prev_tip.height() == 0 {
         log_debug!(logger, "Performing a full chain scan.");
-        let spks = wallet
-            .all_unbounded_spk_iters()
-            .get(&KeychainKind::External)
-            .unwrap()
-            .to_owned();
+        let mut spk_iters = wallet.all_unbounded_spk_iters();
+        let external_spks = spk_iters
+            .remove(&KeychainKind::External)
+            .expect("wallet has an external keychain");
+        let internal_spks = spk_iters
+            .remove(&KeychainKind::Internal)
+            .expect("wallet has an internal keychain");
         let chain = FullScanRequest::builder()
-            .spks_for_keychain(KeychainKind::External, spks.clone())
+            .spks_for_keychain(KeychainKind::External, external_spks)
+            .spks_for_keychain(KeychainKind::Internal, internal_spks)
             .chain_tip(prev_tip)
             .build();
         let sync = blockchain
             .async_client
-            .full_scan(chain, 10, 1)
+            .full_scan(chain, STOP_GAP, PARALLEL_REQUESTS)
             .await
             .map_err(|e| WalletError::Esplora(e.to_string()))?;
         Update {

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -5,7 +5,6 @@ use crate::{chain::EsploraClient, logger::Logger};
 use bdk_chain::spk_client::FullScanRequest;
 use bdk_esplora::EsploraAsyncExt;
 use bdk_wallet::{KeychainKind, PersistedWallet, Update};
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, WalletError>;
@@ -55,11 +54,7 @@ pub async fn sync(
             .full_scan(chain, STOP_GAP, PARALLEL_REQUESTS)
             .await
             .map_err(|e| WalletError::Esplora(e.to_string()))?;
-        Update {
-            last_active_indices: sync.last_active_indices,
-            tx_update: sync.tx_update,
-            chain: sync.chain_update,
-        }
+        Update::from(sync)
     } else {
         // Tell esplora which txids we expect under our SPKs. Expected txids
         // that no longer show up come back stamped as evicted, which drops
@@ -78,21 +73,14 @@ pub async fn sync(
             .expected_spk_txids(expected_spk_txids)
             .chain_tip(prev_tip)
             .build();
+        // A sync (not a full scan) must not set last-active indices: the
+        // update is built from the sync result alone.
         let sync = blockchain
             .async_client
-            .sync(spks, 1)
+            .sync(spks, PARALLEL_REQUESTS)
             .await
             .map_err(|e| WalletError::Esplora(e.to_string()))?;
-        let indices = wallet.derivation_index(KeychainKind::External).unwrap_or(0);
-        let internal_index = wallet.derivation_index(KeychainKind::Internal).unwrap_or(0);
-        let mut last_active_indices = BTreeMap::new();
-        last_active_indices.insert(KeychainKind::External, indices);
-        last_active_indices.insert(KeychainKind::Internal, internal_index);
-        Update {
-            last_active_indices,
-            tx_update: sync.tx_update,
-            chain: sync.chain_update,
-        }
+        Update::from(sync)
     };
     wallet.apply_update(sync_result)?;
     wallet

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -349,7 +349,34 @@ pub async fn send(
     if let Some(min_confirmations) = coin_control.min_confirmations {
         builder.exclude_below_confirmations(min_confirmations);
     }
-    let mut psbt = builder.finish()?;
+    let psbt = builder.finish()?;
+    sign_and_broadcast(wallet, blockchain, storage, psbt).await
+}
+
+/// Builds, signs, and broadcasts an RBF replacement of `txid` at the
+/// higher `fee_rate`. RBF is on by default for wallet transactions.
+#[tracing::instrument(skip(wallet, blockchain, storage))]
+pub async fn bump_fee(
+    wallet: &mut PersistedWallet<WalletStorage>,
+    blockchain: &EsploraClient,
+    storage: &mut WalletStorage,
+    txid: bitcoin::Txid,
+    fee_rate: FeeRate,
+) -> Result<bitcoin::Txid> {
+    let mut builder = wallet.build_fee_bump(txid)?;
+    builder.fee_rate(fee_rate);
+    let psbt = builder.finish()?;
+    sign_and_broadcast(wallet, blockchain, storage, psbt).await
+}
+
+/// Signs a built PSBT, broadcasts the transaction, and persists the
+/// wallet so the revealed change index survives a restart.
+async fn sign_and_broadcast(
+    wallet: &mut PersistedWallet<WalletStorage>,
+    blockchain: &EsploraClient,
+    storage: &mut WalletStorage,
+    mut psbt: bitcoin::Psbt,
+) -> Result<bitcoin::Txid> {
     wallet.sign(&mut psbt, bdk_wallet::SignOptions::default())?;
     let tx = psbt.extract_tx().map_err(|_| WalletError::ExtractTx)?;
     let txid = tx.compute_txid();

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -33,6 +33,10 @@ pub async fn sync(
     events: &broadcast::Sender<WalletEvent>,
     logger: Arc<Logger>,
 ) -> Result<()> {
+    // Keep the fee rate cache fresh; a failed fetch keeps the cached
+    // rates and never fails the sync.
+    blockchain.refresh_fee_estimates().await;
+
     let block_height = blockchain
         .async_client
         .get_height()

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -30,10 +30,6 @@ pub async fn sync(
         .map_err(|e| WalletError::Esplora(e.to_string()))?;
     let prev_tip = wallet.latest_checkpoint();
 
-    if prev_tip.height() == block_height {
-        return Ok(());
-    }
-
     log_debug!(
         logger,
         "Syncing wallet with latest known height. height={} wallet_height={}",

--- a/ddk/src/wallet/command.rs
+++ b/ddk/src/wallet/command.rs
@@ -4,7 +4,12 @@ use crate::logger::{log_debug, WriteLog};
 use crate::{chain::EsploraClient, logger::Logger};
 use bdk_chain::spk_client::FullScanRequest;
 use bdk_esplora::EsploraAsyncExt;
-use bdk_wallet::{KeychainKind, PersistedWallet, Update};
+use bdk_wallet::coin_selection::{
+    BranchAndBoundCoinSelection, CoinSelectionAlgorithm, SingleRandomDraw,
+};
+use bdk_wallet::{KeychainKind, PersistedWallet, Update, Utxo, WeightedUtxo};
+use bitcoin::key::rand::thread_rng;
+use bitcoin::{Address, Amount, FeeRate, ScriptBuf};
 use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, WalletError>;
@@ -88,4 +93,68 @@ pub async fn sync(
         .await
         .map_err(|e| WalletError::WalletPersistanceError(e.to_string()))?;
     Ok(())
+}
+
+/// Selects UTXOs that cover `amount` at `fee_rate`, ignoring locked
+/// outpoints. When `lock_utxos` is set, the selected outpoints are locked and
+/// the locks are persisted, so a concurrent selection cannot pick the same
+/// coins and the locks survive a restart.
+#[tracing::instrument(skip(wallet, storage))]
+pub async fn select_utxos(
+    wallet: &mut PersistedWallet<WalletStorage>,
+    storage: &mut WalletStorage,
+    amount: Amount,
+    fee_rate: u64,
+    lock_utxos: bool,
+) -> Result<Vec<ddk_manager::Utxo>> {
+    let candidates = wallet
+        .list_unspent()
+        .filter(|utxo| !wallet.is_outpoint_locked(utxo.outpoint))
+        .map(|utxo| WeightedUtxo {
+            satisfaction_weight: utxo.txout.weight(),
+            utxo: Utxo::Local(utxo),
+        })
+        .collect::<Vec<WeightedUtxo>>();
+
+    let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
+        .ok_or_else(|| WalletError::Esplora(format!("Invalid fee rate: {fee_rate}")))?;
+
+    let selected = BranchAndBoundCoinSelection::new(super::MIN_CHANGE_SIZE, SingleRandomDraw)
+        .coin_select(
+            vec![],
+            candidates,
+            fee_rate,
+            amount,
+            ScriptBuf::new().as_script(),
+            &mut thread_rng(),
+        )?;
+
+    let network = wallet.network();
+    let utxos = selected
+        .selected
+        .iter()
+        .map(|utxo| {
+            let address = Address::from_script(&utxo.txout().script_pubkey, network)
+                .expect("wallet outputs have addressable script pubkeys");
+            ddk_manager::Utxo {
+                tx_out: utxo.txout().clone(),
+                outpoint: utxo.outpoint(),
+                address,
+                redeem_script: ScriptBuf::new(),
+                reserved: lock_utxos,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if lock_utxos {
+        for utxo in &utxos {
+            wallet.lock_outpoint(utxo.outpoint);
+        }
+        wallet
+            .persist_async(storage)
+            .await
+            .map_err(|e| WalletError::WalletPersistanceError(e.to_string()))?;
+    }
+
+    Ok(utxos)
 }

--- a/ddk/src/wallet/contract_tracker.rs
+++ b/ddk/src/wallet/contract_tracker.rs
@@ -1,0 +1,364 @@
+//! Chain-truth tracking of DLC funding outputs.
+//!
+//! The 2-of-2 funding output of a contract is invisible to the BDK wallet:
+//! it pays a P2WSH script that no wallet descriptor expresses. The tracker
+//! indexes each contract's funding script over its own transaction graph
+//! with the `bdk_chain` primitives, sharing the wallet's local chain view.
+//! Confirmation of the funding transaction and any spend of the funding
+//! output (CET, refund, or counterparty close) then come from the chain
+//! instead of collateral math.
+
+use bdk_chain::indexed_tx_graph::IndexedTxGraph;
+use bdk_chain::indexer::spk_txout::SpkTxOutIndex;
+use bdk_chain::local_chain::LocalChain;
+use bdk_chain::{
+    Balance, CanonicalizationParams, ChainPosition, ConfirmationBlockTime, Merge, TxUpdate,
+};
+use bitcoin::{OutPoint, ScriptBuf, Txid};
+use ddk_manager::ContractId;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A contract funding output with its chain state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContractUtxo {
+    /// The contract this funding output belongs to
+    pub contract_id: ContractId,
+    /// The funding outpoint
+    pub outpoint: OutPoint,
+    /// The funding output
+    pub txout: bitcoin::TxOut,
+    /// Whether the funding transaction is confirmed
+    pub confirmed: bool,
+    /// The transaction that spent the funding output, when the chain
+    /// knows one (CET, refund, or counterparty close)
+    pub spent_by: Option<Txid>,
+}
+
+/// The serde changeset of the tracker, persisted through the `Storage`
+/// trait next to the wallet changeset.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ChangeSet {
+    /// Funding script registrations by contract
+    pub spks: BTreeMap<ContractId, ScriptBuf>,
+    /// The transaction graph changes
+    pub tx_graph: bdk_chain::tx_graph::ChangeSet<ConfirmationBlockTime>,
+}
+
+impl Merge for ChangeSet {
+    fn merge(&mut self, other: Self) {
+        self.spks.extend(other.spks);
+        self.tx_graph.merge(other.tx_graph);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.spks.is_empty() && self.tx_graph.is_empty()
+    }
+}
+
+/// Tracks contract funding outputs beside the wallet.
+///
+/// The tracker owns a transaction graph indexed by contract id and shares
+/// the wallet's [`LocalChain`] view, which the caller passes into the query
+/// methods. Changes stage into a [`ChangeSet`] the caller persists.
+pub struct ContractUtxoTracker {
+    graph: IndexedTxGraph<ConfirmationBlockTime, SpkTxOutIndex<ContractId>>,
+    stage: ChangeSet,
+}
+
+impl Default for ContractUtxoTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContractUtxoTracker {
+    /// Creates an empty tracker.
+    pub fn new() -> Self {
+        Self {
+            graph: IndexedTxGraph::new(SpkTxOutIndex::default()),
+            stage: ChangeSet::default(),
+        }
+    }
+
+    /// Rebuilds a tracker from a persisted changeset.
+    pub fn from_changeset(changeset: ChangeSet) -> Self {
+        let mut index = SpkTxOutIndex::default();
+        for (contract_id, spk) in &changeset.spks {
+            index.insert_spk(*contract_id, spk.clone());
+        }
+        let mut graph = IndexedTxGraph::new(index);
+        graph.apply_changeset(bdk_chain::indexed_tx_graph::ChangeSet {
+            tx_graph: changeset.tx_graph,
+            indexer: (),
+        });
+        Self {
+            graph,
+            stage: ChangeSet::default(),
+        }
+    }
+
+    /// Registers a contract's funding script. Idempotent; returns whether
+    /// the script was new. Transactions already in the graph are
+    /// re-indexed so a late registration still finds its output.
+    pub fn register(&mut self, contract_id: ContractId, spk: ScriptBuf) -> bool {
+        if self.graph.index.spk_at_index(&contract_id) == Some(spk.clone()) {
+            return false;
+        }
+        self.graph.index.insert_spk(contract_id, spk.clone());
+        let _ = self.graph.reindex();
+        self.stage.spks.insert(contract_id, spk);
+        true
+    }
+
+    /// Whether the contract's funding script is registered.
+    pub fn contains(&self, contract_id: &ContractId) -> bool {
+        self.graph.index.spk_at_index(contract_id).is_some()
+    }
+
+    /// The funding scripts to carry in a targeted sync request.
+    pub fn sync_spks(&self) -> Vec<ScriptBuf> {
+        self.graph.index.all_spks().values().cloned().collect()
+    }
+
+    /// The known funding outpoints to carry in a targeted sync request,
+    /// so esplora resolves their spend status.
+    pub fn sync_outpoints(&self) -> Vec<OutPoint> {
+        self.graph
+            .index
+            .outpoints()
+            .iter()
+            .map(|(_, outpoint)| *outpoint)
+            .collect()
+    }
+
+    /// Applies a transaction update from a sync and stages the change.
+    pub fn apply_update(&mut self, update: TxUpdate<ConfirmationBlockTime>) {
+        let changeset = self.graph.apply_update(update);
+        self.stage.merge(ChangeSet {
+            spks: BTreeMap::new(),
+            tx_graph: changeset.tx_graph,
+        });
+    }
+
+    /// The balance over the tracked funding outputs, from chain truth.
+    /// All tracked outputs are trusted: both parties signed the funding
+    /// transaction.
+    pub fn balance(&self, chain: &LocalChain) -> Balance {
+        self.graph.graph().balance(
+            chain,
+            chain.tip().block_id(),
+            CanonicalizationParams::default(),
+            self.graph.index.outpoints().iter().cloned(),
+            |_, _| true,
+        )
+    }
+
+    /// The tracked funding outputs with their chain state, including the
+    /// spent ones so a caller can observe a close.
+    pub fn utxos(&self, chain: &LocalChain) -> Vec<ContractUtxo> {
+        self.graph
+            .graph()
+            .filter_chain_txouts(
+                chain,
+                chain.tip().block_id(),
+                CanonicalizationParams::default(),
+                self.graph.index.outpoints().iter().cloned(),
+            )
+            .map(|(contract_id, full_txout)| ContractUtxo {
+                contract_id,
+                outpoint: full_txout.outpoint,
+                txout: full_txout.txout,
+                confirmed: matches!(full_txout.chain_position, ChainPosition::Confirmed { .. }),
+                spent_by: full_txout.spent_by.map(|(_, txid)| txid),
+            })
+            .collect()
+    }
+
+    /// Takes the staged changeset for persistence, if any.
+    pub fn take_staged(&mut self) -> Option<ChangeSet> {
+        if self.stage.is_empty() {
+            None
+        } else {
+            Some(core::mem::take(&mut self.stage))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bdk_chain::BlockId;
+    use bitcoin::hashes::Hash;
+    use bitcoin::{
+        absolute::LockTime, transaction::Version, Amount, BlockHash, OutPoint, Sequence,
+        Transaction, TxIn, TxOut, Witness,
+    };
+
+    fn funding_spk() -> ScriptBuf {
+        // Any script works for the index; a P2WSH-shaped one keeps the
+        // test honest.
+        ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array([0xCD; 32]))
+    }
+
+    fn chain_with_blocks(blocks: u32) -> LocalChain {
+        let (mut chain, _) = LocalChain::from_genesis_hash(BlockHash::from_byte_array([0; 32]));
+        for height in 1..=blocks {
+            let mut hash = [0u8; 32];
+            hash[..4].copy_from_slice(&height.to_be_bytes());
+            let _ = chain
+                .insert_block(BlockId {
+                    height,
+                    hash: BlockHash::from_byte_array(hash),
+                })
+                .unwrap();
+        }
+        chain
+    }
+
+    fn funding_tx(spk: ScriptBuf) -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(200_000),
+                script_pubkey: spk,
+            }],
+        }
+    }
+
+    fn anchor_at(chain: &LocalChain, height: u32) -> ConfirmationBlockTime {
+        ConfirmationBlockTime {
+            block_id: chain.get(height).unwrap().block_id(),
+            confirmation_time: 100,
+        }
+    }
+
+    #[test]
+    fn tracks_funding_confirmation_and_spend() {
+        let chain = chain_with_blocks(3);
+        let contract_id = [0x11; 32];
+        let spk = funding_spk();
+
+        let mut tracker = ContractUtxoTracker::new();
+        assert!(tracker.register(contract_id, spk.clone()));
+        assert!(!tracker.register(contract_id, spk.clone()));
+
+        // Unconfirmed funding transaction: a pending balance.
+        let fund = funding_tx(spk.clone());
+        let fund_txid = fund.compute_txid();
+        let mut update = TxUpdate::default();
+        update.txs.push(fund.clone().into());
+        update.seen_ats.insert((fund_txid, 100));
+        tracker.apply_update(update);
+
+        let balance = tracker.balance(&chain);
+        assert_eq!(balance.trusted_pending, Amount::from_sat(200_000));
+        assert_eq!(balance.confirmed, Amount::ZERO);
+
+        // Confirmation moves the balance and marks the utxo confirmed.
+        let mut update = TxUpdate::default();
+        update.anchors.insert((anchor_at(&chain, 2), fund_txid));
+        tracker.apply_update(update);
+
+        let balance = tracker.balance(&chain);
+        assert_eq!(balance.confirmed, Amount::from_sat(200_000));
+        let utxos = tracker.utxos(&chain);
+        assert_eq!(utxos.len(), 1);
+        assert!(utxos[0].confirmed);
+        assert_eq!(utxos[0].spent_by, None);
+        assert_eq!(utxos[0].contract_id, contract_id);
+
+        // A spend of the funding output (a CET) is observed.
+        let cet = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: fund_txid,
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(199_000),
+                script_pubkey: ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array(
+                    [0xEE; 32],
+                )),
+            }],
+        };
+        let cet_txid = cet.compute_txid();
+        let mut update = TxUpdate::default();
+        update.txs.push(cet.into());
+        update.anchors.insert((anchor_at(&chain, 3), cet_txid));
+        tracker.apply_update(update);
+
+        let balance = tracker.balance(&chain);
+        assert_eq!(balance.confirmed, Amount::ZERO);
+        let utxos = tracker.utxos(&chain);
+        assert_eq!(utxos.len(), 1);
+        assert_eq!(utxos[0].spent_by, Some(cet_txid));
+    }
+
+    #[test]
+    fn changeset_round_trips() {
+        let chain = chain_with_blocks(2);
+        let contract_id = [0x22; 32];
+        let spk = funding_spk();
+
+        let mut tracker = ContractUtxoTracker::new();
+        tracker.register(contract_id, spk.clone());
+        let fund = funding_tx(spk);
+        let fund_txid = fund.compute_txid();
+        let mut update = TxUpdate::default();
+        update.txs.push(fund.into());
+        update.anchors.insert((anchor_at(&chain, 2), fund_txid));
+        tracker.apply_update(update);
+
+        let staged = tracker.take_staged().unwrap();
+        assert!(tracker.take_staged().is_none());
+
+        let restored = ContractUtxoTracker::from_changeset(staged);
+        assert!(restored.contains(&contract_id));
+        assert_eq!(
+            restored.balance(&chain).confirmed,
+            Amount::from_sat(200_000)
+        );
+        assert_eq!(restored.utxos(&chain), tracker.utxos(&chain));
+    }
+
+    #[test]
+    fn late_registration_finds_existing_outputs() {
+        let chain = chain_with_blocks(2);
+        let spk = funding_spk();
+
+        // The funding transaction lands in the graph before the contract
+        // is registered (restore path).
+        let mut tracker = ContractUtxoTracker::new();
+        tracker.register(
+            [0x01; 32],
+            ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::from_byte_array([0x0F; 32])),
+        );
+        let fund = funding_tx(spk.clone());
+        let fund_txid = fund.compute_txid();
+        let mut update = TxUpdate::default();
+        update.txs.push(fund.into());
+        update.anchors.insert((anchor_at(&chain, 2), fund_txid));
+        tracker.apply_update(update);
+        assert_eq!(tracker.balance(&chain).confirmed, Amount::ZERO);
+
+        tracker.register([0x33; 32], spk);
+        assert_eq!(tracker.balance(&chain).confirmed, Amount::from_sat(200_000));
+    }
+}

--- a/ddk/src/wallet/contract_tracker.rs
+++ b/ddk/src/wallet/contract_tracker.rs
@@ -39,10 +39,31 @@ pub struct ContractUtxo {
 /// trait next to the wallet changeset.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ChangeSet {
-    /// Funding script registrations by contract
+    /// Funding script registrations by contract. Serialized as a list of
+    /// pairs: a JSON map cannot key on a byte array.
+    #[serde(with = "spk_map_serde")]
     pub spks: BTreeMap<ContractId, ScriptBuf>,
     /// The transaction graph changes
     pub tx_graph: bdk_chain::tx_graph::ChangeSet<ConfirmationBlockTime>,
+}
+
+mod spk_map_serde {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        map: &BTreeMap<ContractId, ScriptBuf>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serde::Serialize::serialize(&map.iter().collect::<Vec<_>>(), serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<BTreeMap<ContractId, ScriptBuf>, D::Error> {
+        let entries: Vec<(ContractId, ScriptBuf)> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(entries.into_iter().collect())
+    }
 }
 
 impl Merge for ChangeSet {

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -168,6 +168,9 @@ pub enum WalletCommand {
         Vec<bitcoin::OutPoint>,
         oneshot::Sender<Result<()>>,
     ),
+
+    /// List the currently locked outpoints
+    ListLockedOutpoints(oneshot::Sender<Vec<bitcoin::OutPoint>>),
 }
 
 /// The main wallet implementation that provides Bitcoin functionality for DDK.
@@ -503,7 +506,32 @@ impl DlcDevKitWallet {
                         // input-by-input finds later inputs already
                         // finalized, so the signing work is done one time.
                         let result = match wallet.sign(&mut psbt, sign_opts) {
-                            Ok(_) => Ok(psbt),
+                            Ok(_) => {
+                                // A signed funding transaction can stay
+                                // unbroadcast while the counterparty
+                                // finishes the protocol. Lock its wallet
+                                // inputs so a concurrent selection cannot
+                                // double-spend them; the locks release when
+                                // the spend confirms.
+                                let wallet_inputs = psbt
+                                    .unsigned_tx
+                                    .input
+                                    .iter()
+                                    .map(|input| input.previous_output)
+                                    .filter(|outpoint| wallet.get_utxo(*outpoint).is_some())
+                                    .collect::<Vec<_>>();
+                                for outpoint in wallet_inputs {
+                                    wallet.lock_outpoint(outpoint);
+                                }
+                                if let Err(e) = wallet.persist_async(&mut storage).await {
+                                    log_error!(
+                                        logger_clone,
+                                        "Could not persist locks for signed funding inputs. error={:?}",
+                                        e
+                                    );
+                                }
+                                Ok(psbt)
+                            }
                             Err(e) => {
                                 log_error!(logger_clone, "Could not sign PSBT. error={:?}", e);
                                 Err(ManagerError::WalletError(WalletError::Signing(e).into()))
@@ -558,6 +586,16 @@ impl DlcDevKitWallet {
                         // The responder is already dropped when the manager
                         // fires this command without waiting.
                         let _ = responder.send(result);
+                    }
+                    WalletCommand::ListLockedOutpoints(responder) => {
+                        let outpoints = wallet.list_locked_outpoints().collect();
+                        let _ = responder.send(outpoints).map_err(|e| {
+                            log_error!(
+                                logger_clone,
+                                "Error sending list locked outpoints command. error={:?}",
+                                e
+                            );
+                        });
                     }
                 }
             }
@@ -692,6 +730,16 @@ impl DlcDevKitWallet {
             .send(WalletCommand::UnlockOutpoints(outpoints, tx))
             .await?;
         rx.await.map_err(WalletError::Receiver)?
+    }
+
+    /// Lists the outpoints that are locked against coin selection.
+    #[tracing::instrument(skip(self))]
+    pub async fn locked_outpoints(&self) -> Result<Vec<bitcoin::OutPoint>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::ListLockedOutpoints(tx))
+            .await?;
+        rx.await.map_err(WalletError::Receiver)
     }
 
     /// Signs a specific input in a PSBT for DLC operations.
@@ -1224,6 +1272,65 @@ mod tests {
         // queued command.
         wallet.unreserve_utxos(&outpoints).unwrap();
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn signed_funding_inputs_lock_until_confirmation() {
+        use bitcoincore_rpc::RpcApi;
+        use ddk_manager::Wallet;
+
+        let wallet = create_wallet().await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        fund_address(&address);
+        wallet.sync().await.unwrap();
+
+        let utxos = wallet.list_utxos().await.unwrap();
+        assert_eq!(utxos.len(), 1);
+        let utxo = utxos[0].clone();
+
+        // A funding transaction that spends the wallet coin, signed
+        // through the manager path but not broadcast.
+        let dest = Address::from_str("bcrt1qt0yrvs7qx8guvpqsx8u9mypz6t4zr3pxthsjkm")
+            .unwrap()
+            .assume_checked();
+        let unsigned = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn {
+                previous_output: utxo.outpoint,
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: bitcoin::Witness::new(),
+            }],
+            output: vec![bitcoin::TxOut {
+                value: utxo.txout.value - Amount::from_sat(1_000),
+                script_pubkey: dest.script_pubkey(),
+            }],
+        };
+        let mut psbt = bitcoin::Psbt::from_unsigned_tx(unsigned).unwrap();
+        psbt.inputs[0].witness_utxo = Some(utxo.txout.clone());
+
+        wallet.sign_psbt_input(&mut psbt, 0).await.unwrap();
+        assert!(psbt.inputs[0].final_script_witness.is_some());
+
+        // The signed-but-unbroadcast input is locked and not selectable.
+        assert_eq!(
+            wallet.locked_outpoints().await.unwrap(),
+            vec![utxo.outpoint]
+        );
+        assert!(wallet
+            .get_utxos_for_amount(Amount::from_btc(0.5).unwrap(), 1, true)
+            .await
+            .is_err());
+
+        // Broadcast and confirm the spend: the sync releases the lock.
+        let tx = psbt.extract_tx().unwrap();
+        let env = ddk_testenv::env();
+        let txid = env.rpc().send_raw_transaction(&tx).unwrap();
+        env.wait_for_tx(&txid);
+        generate_blocks(1);
+        wallet.sync().await.unwrap();
+        assert!(wallet.locked_outpoints().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -295,6 +295,8 @@ impl DlcDevKitWallet {
 
         let (sender, mut receiver) = channel(100);
 
+        let mut tracker = contract_tracker::ContractUtxoTracker::new();
+
         let logger_clone = logger.clone();
         tokio::spawn(async move {
             while let Some(command) = receiver.recv().await {
@@ -302,6 +304,7 @@ impl DlcDevKitWallet {
                     WalletCommand::Sync(sender) => {
                         let sync = command::sync(
                             &mut wallet,
+                            &mut tracker,
                             &blockchain,
                             &mut storage,
                             logger_clone.clone(),

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -49,12 +49,10 @@ use bitcoin::Psbt;
 use bitcoin::{secp256k1::SecretKey, Amount, FeeRate, Transaction};
 use ddk_manager::{error::Error as ManagerError, SimpleSigner};
 use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::AtomicU32;
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::Arc;
 use tokio::sync::{
     mpsc::{channel, Sender},
     oneshot,
@@ -220,6 +218,8 @@ pub struct DlcDevKitWallet {
     /// Broadcast sender for wallet events; new subscribers come from
     /// [`DlcDevKitWallet::subscribe_events`]
     events: tokio::sync::broadcast::Sender<WalletEvent>,
+    /// Esplora client, the source of the cached live fee estimates
+    blockchain: Arc<EsploraClient>,
     /// Bitcoin network (mainnet, testnet, regtest)
     network: Network,
     /// Extended private key for the wallet
@@ -235,8 +235,6 @@ pub struct DlcDevKitWallet {
     /// Logger
     logger: Arc<Logger>,
 }
-
-const MIN_FEERATE: u32 = 253;
 
 impl DlcDevKitWallet {
     /// Creates a new DlcDevKitWallet instance.
@@ -306,6 +304,7 @@ impl DlcDevKitWallet {
 
         let (sender, mut receiver) = channel(100);
         let (events, _) = tokio::sync::broadcast::channel(256);
+        let blockchain_handle = blockchain.clone();
 
         let mut tracker = contract_tracker::ContractUtxoTracker::from_changeset(
             storage.0.initialize_contract_tracker().await?,
@@ -669,6 +668,7 @@ impl DlcDevKitWallet {
         Ok(DlcDevKitWallet {
             sender,
             events,
+            blockchain: blockchain_handle,
             network,
             xprv,
             secp,
@@ -867,14 +867,12 @@ impl DlcDevKitWallet {
 /// Implementation of Lightning's FeeEstimator trait for the wallet.
 /// Provides fee estimation for DLC operations based on confirmation targets.
 impl FeeEstimator for DlcDevKitWallet {
-    /// Returns the estimated fee rate in satoshis per 1000 weight units.
-    /// Used by the DLC manager to estimate fees for funding transactions.
+    /// Returns the estimated fee rate in satoshis per 1000 weight units,
+    /// from the fee cache the esplora client refreshes on each sync.
     #[tracing::instrument(skip(self))]
     fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
-        let fees = fee_estimator();
-        fees.get(&confirmation_target)
-            .unwrap()
-            .load(Ordering::Acquire)
+        self.blockchain
+            .get_est_sat_per_1000_weight(confirmation_target)
     }
 }
 
@@ -1045,44 +1043,6 @@ impl ddk_manager::Wallet for DlcDevKitWallet {
             .map_err(|e| wallet_err_to_manager_err(WalletError::Receiver(e)))?
             .map_err(wallet_err_to_manager_err)
     }
-}
-
-/// Creates a fee estimator with predefined fee rates for different confirmation targets.
-///
-/// This function sets up fee estimation for different urgency levels:
-/// - High Priority: For immediate confirmation
-/// - Normal: For confirmation within a few blocks  
-/// - Background: For non-urgent transactions
-///
-/// Returns a HashMap mapping confirmation targets to atomic fee rates.
-fn fee_estimator() -> HashMap<ConfirmationTarget, AtomicU32> {
-    let mut fees: HashMap<ConfirmationTarget, AtomicU32> = HashMap::new();
-    fees.insert(ConfirmationTarget::UrgentOnChainSweep, AtomicU32::new(5000));
-    fees.insert(
-        ConfirmationTarget::MinAllowedAnchorChannelRemoteFee,
-        AtomicU32::new(25 * 250),
-    );
-    fees.insert(
-        ConfirmationTarget::MinAllowedAnchorChannelRemoteFee,
-        AtomicU32::new(MIN_FEERATE),
-    );
-    fees.insert(
-        ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee,
-        AtomicU32::new(MIN_FEERATE),
-    );
-    fees.insert(
-        ConfirmationTarget::AnchorChannelFee,
-        AtomicU32::new(MIN_FEERATE),
-    );
-    fees.insert(
-        ConfirmationTarget::NonAnchorChannelFee,
-        AtomicU32::new(2000),
-    );
-    fees.insert(
-        ConfirmationTarget::ChannelCloseMinimum,
-        AtomicU32::new(MIN_FEERATE),
-    );
-    fees
 }
 
 impl Debug for DlcDevKitWallet {

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -31,9 +31,6 @@ use crate::logger::{log_error, log_info, WriteLog};
 use crate::wallet::address::AddressGenerator;
 use crate::{chain::EsploraClient, Storage};
 use bdk_chain::Balance;
-use bdk_wallet::coin_selection::{
-    BranchAndBoundCoinSelection, CoinSelectionAlgorithm, SingleRandomDraw,
-};
 use bdk_wallet::descriptor::IntoWalletDescriptor;
 use bdk_wallet::AsyncWalletPersister;
 pub use bdk_wallet::LocalOutput;
@@ -46,11 +43,9 @@ use bdk_wallet::{
     template::Bip84,
     AddressInfo, KeychainKind, SignOptions, Wallet,
 };
-use bdk_wallet::{Utxo, WeightedUtxo};
 use bitcoin::bip32::Fingerprint;
-use bitcoin::key::rand::thread_rng;
 use bitcoin::Psbt;
-use bitcoin::{secp256k1::SecretKey, Amount, FeeRate, ScriptBuf, Transaction};
+use bitcoin::{secp256k1::SecretKey, Amount, FeeRate, Transaction};
 use ddk_manager::{error::Error as ManagerError, SimpleSigner};
 use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
 use std::collections::HashMap;
@@ -155,6 +150,18 @@ pub enum WalletCommand {
         bitcoin::psbt::Psbt,
         oneshot::Sender<std::result::Result<Psbt, ManagerError>>,
     ),
+
+    /// Select UTXOs that cover an amount, optionally locking them
+    SelectUtxos {
+        /// The amount the selection must cover
+        amount: Amount,
+        /// Fee rate in sat/vB the selection pays for its own weight
+        fee_rate: u64,
+        /// Lock the selected outpoints against concurrent selections
+        lock_utxos: bool,
+        /// Channel for receiving the selected UTXOs
+        responder: oneshot::Sender<Result<Vec<ddk_manager::Utxo>>>,
+    },
 }
 
 /// The main wallet implementation that provides Bitcoin functionality for DDK.
@@ -504,6 +511,28 @@ impl DlcDevKitWallet {
                             );
                         });
                     }
+                    WalletCommand::SelectUtxos {
+                        amount,
+                        fee_rate,
+                        lock_utxos,
+                        responder,
+                    } => {
+                        let result = command::select_utxos(
+                            &mut wallet,
+                            &mut storage,
+                            amount,
+                            fee_rate,
+                            lock_utxos,
+                        )
+                        .await;
+                        let _ = responder.send(result).map_err(|e| {
+                            log_error!(
+                                logger_clone,
+                                "Error sending select utxos command. error={:?}",
+                                e
+                            );
+                        });
+                    }
                 }
             }
         });
@@ -808,13 +837,15 @@ impl ddk_manager::Wallet for DlcDevKitWallet {
     /// Selects UTXOs for a specific amount and fee rate.
     ///
     /// This method is used by the DLC manager to select appropriate UTXOs
-    /// for funding DLC transactions. It performs coin selection based on the
-    /// requested amount and fee rate.
+    /// for funding DLC transactions. Locked outpoints are never selected.
+    /// When `lock_utxos` is set, the selected outpoints are locked and the
+    /// locks persist across restarts, so two concurrent offers cannot fund
+    /// themselves with the same coins.
     ///
     /// # Arguments
     /// * `amount` - The amount of Bitcoin needed
     /// * `fee_rate` - The fee rate for the transaction
-    /// * `_lock_utxos` - Whether to lock the selected UTXOs (currently unused)
+    /// * `lock_utxos` - Whether to lock the selected UTXOs
     ///
     /// # Returns
     /// A vector of UTXOs that can cover the required amount plus fees
@@ -823,50 +854,21 @@ impl ddk_manager::Wallet for DlcDevKitWallet {
         &self,
         amount: Amount,
         fee_rate: u64,
-        _lock_utxos: bool,
+        lock_utxos: bool,
     ) -> std::result::Result<Vec<ddk_manager::Utxo>, ManagerError> {
-        let local_utxos = self.list_utxos().await.map_err(wallet_err_to_manager_err)?;
-
-        let utxos = local_utxos
-            .iter()
-            .map(|utxo| WeightedUtxo {
-                satisfaction_weight: utxo.txout.weight(),
-                utxo: Utxo::Local(utxo.clone()),
-            })
-            .collect::<Vec<WeightedUtxo>>();
-
-        let selected_utxos = BranchAndBoundCoinSelection::new(MIN_CHANGE_SIZE, SingleRandomDraw)
-            .coin_select(
-                vec![],
-                utxos,
-                FeeRate::from_sat_per_vb(fee_rate).ok_or_else(|| {
-                    ManagerError::WalletError(Box::new(WalletError::Esplora(format!(
-                        "Invalid fee rate: {fee_rate}"
-                    ))))
-                })?,
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::SelectUtxos {
                 amount,
-                ScriptBuf::new().as_script(),
-                &mut thread_rng(),
-            )
-            .map_err(|e| ManagerError::WalletError(Box::new(e)))?;
-
-        let dlc_utxos = selected_utxos
-            .selected
-            .iter()
-            .map(|utxo| {
-                let address =
-                    Address::from_script(&utxo.txout().script_pubkey, self.network).unwrap();
-                ddk_manager::Utxo {
-                    tx_out: utxo.txout().clone(),
-                    outpoint: utxo.outpoint(),
-                    address,
-                    redeem_script: ScriptBuf::new(),
-                    reserved: false,
-                }
+                fee_rate,
+                lock_utxos,
+                responder: tx,
             })
-            .collect();
-
-        Ok(dlc_utxos)
+            .await
+            .map_err(|e| wallet_err_to_manager_err(WalletError::Sender(e)))?;
+        rx.await
+            .map_err(|e| wallet_err_to_manager_err(WalletError::Receiver(e)))?
+            .map_err(wallet_err_to_manager_err)
     }
 }
 
@@ -937,7 +939,14 @@ mod tests {
     }
 
     async fn create_wallet_on(esplora: &str, seed: &[u8; 64]) -> DlcDevKitWallet {
-        let storage = Arc::new(MemoryStorage::new());
+        create_wallet_with_storage(esplora, seed, Arc::new(MemoryStorage::new())).await
+    }
+
+    async fn create_wallet_with_storage(
+        esplora: &str,
+        seed: &[u8; 64],
+        storage: Arc<MemoryStorage>,
+    ) -> DlcDevKitWallet {
         let logger = Arc::new(Logger::console(
             "console_logger".to_string(),
             LogLevel::Info,
@@ -948,7 +957,7 @@ mod tests {
             seed,
             esplora,
             Network::Regtest,
-            storage.clone(),
+            storage,
             None,
             logger.clone(),
         )
@@ -1112,6 +1121,61 @@ mod tests {
             wallet.get_balance().await.unwrap().untrusted_pending,
             Amount::ZERO
         );
+    }
+
+    #[tokio::test]
+    async fn concurrent_selections_never_overlap() {
+        use ddk_manager::Wallet;
+
+        let wallet = create_wallet().await;
+        let addr_one = wallet.new_external_address().await.unwrap().address;
+        let addr_two = wallet.new_external_address().await.unwrap().address;
+        fund_address(&addr_one);
+        fund_address(&addr_two);
+        wallet.sync().await.unwrap();
+
+        let amount = Amount::from_btc(0.5).unwrap();
+        let first = wallet.get_utxos_for_amount(amount, 1, true).await.unwrap();
+        let second = wallet.get_utxos_for_amount(amount, 1, true).await.unwrap();
+
+        assert!(!first.is_empty());
+        assert!(!second.is_empty());
+        assert!(first.iter().all(|utxo| utxo.reserved));
+        for utxo in &first {
+            assert!(second.iter().all(|other| other.outpoint != utxo.outpoint));
+        }
+
+        // Every coin is locked now: a third selection has nothing to spend.
+        assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn utxo_locks_survive_restart() {
+        use ddk_manager::Wallet;
+
+        let esplora = ddk_testenv::env().esplora_host().to_string();
+        let storage = Arc::new(MemoryStorage::new());
+        let mut seed = [0u8; 64];
+        seed.try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+
+        let wallet = create_wallet_with_storage(&esplora, &seed, storage.clone()).await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        fund_address(&address);
+        wallet.sync().await.unwrap();
+
+        let amount = Amount::from_btc(0.5).unwrap();
+        let selected = wallet.get_utxos_for_amount(amount, 1, true).await.unwrap();
+        assert!(!selected.is_empty());
+
+        // A wallet loaded from the same storage sees the persisted locks
+        // and cannot select the locked coin.
+        let restarted = create_wallet_with_storage(&esplora, &seed, storage.clone()).await;
+        restarted.sync().await.unwrap();
+        assert!(restarted
+            .get_utxos_for_amount(amount, 1, true)
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -299,7 +299,9 @@ impl DlcDevKitWallet {
 
         let (sender, mut receiver) = channel(100);
 
-        let mut tracker = contract_tracker::ContractUtxoTracker::new();
+        let mut tracker = contract_tracker::ContractUtxoTracker::from_changeset(
+            storage.0.initialize_contract_tracker().await?,
+        );
 
         let logger_clone = logger.clone();
         tokio::spawn(async move {

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -25,6 +25,8 @@ pub mod address;
 mod command;
 pub mod contract_tracker;
 
+pub use command::{CoinControl, Spend};
+
 use crate::contract::ContractKeyProvider;
 use crate::error::{wallet_err_to_manager_err, WalletError};
 use crate::logger::Logger;
@@ -151,11 +153,20 @@ pub enum WalletCommand {
     /// Generate a new internal (change) address
     NewChangeAddress(oneshot::Sender<Result<AddressInfo>>),
 
-    /// Send a specific amount to an address with the given fee rate
-    SendToAddress(Address, Amount, FeeRate, oneshot::Sender<Result<Txid>>),
-
-    /// Send all available funds to an address with the given fee rate
-    SendAll(Address, FeeRate, oneshot::Sender<Result<Txid>>),
+    /// Send to an address: an amount or the whole wallet, with optional
+    /// coin control
+    Send {
+        /// Destination address
+        address: Address,
+        /// What the send spends
+        spend: command::Spend,
+        /// Fee rate of the transaction
+        fee_rate: FeeRate,
+        /// Restrictions on which UTXOs fund the transaction
+        coin_control: command::CoinControl,
+        /// Channel for receiving the transaction id
+        responder: oneshot::Sender<Result<Txid>>,
+    },
 
     /// Get all wallet transactions
     GetTransactions(oneshot::Sender<Result<Vec<Arc<Transaction>>>>),
@@ -392,40 +403,25 @@ impl DlcDevKitWallet {
                             );
                         });
                     }
-                    WalletCommand::SendToAddress(address, amount, fee_rate, sender) => {
+                    WalletCommand::Send {
+                        address,
+                        spend,
+                        fee_rate,
+                        coin_control,
+                        responder,
+                    } => {
                         let result = command::send(
                             &mut wallet,
                             &blockchain,
                             &mut storage,
                             address,
-                            command::Spend::Amount(amount),
+                            spend,
                             fee_rate,
+                            coin_control,
                         )
                         .await;
-                        let _ = sender.send(result).map_err(|e| {
-                            log_error!(
-                                logger_clone,
-                                "Error sending send to address command. error={:?}",
-                                e
-                            );
-                        });
-                    }
-                    WalletCommand::SendAll(address, fee_rate, sender) => {
-                        let result = command::send(
-                            &mut wallet,
-                            &blockchain,
-                            &mut storage,
-                            address,
-                            command::Spend::All,
-                            fee_rate,
-                        )
-                        .await;
-                        let _ = sender.send(result).map_err(|e| {
-                            log_error!(
-                                logger_clone,
-                                "Error sending send all command. error={:?}",
-                                e
-                            );
+                        let _ = responder.send(result).map_err(|e| {
+                            log_error!(logger_clone, "Error sending send command. error={:?}", e);
                         });
                     }
                     WalletCommand::GetTransactions(sender) => {
@@ -667,9 +663,43 @@ impl DlcDevKitWallet {
         amount: Amount,
         fee_rate: FeeRate,
     ) -> Result<Txid> {
+        self.send_with_coin_control(
+            address,
+            Spend::Amount(amount),
+            fee_rate,
+            CoinControl::default(),
+        )
+        .await
+    }
+
+    /// Sends with coin control: caller-selected UTXOs, an unspendable
+    /// exclusion list, and a confirmation floor.
+    ///
+    /// # Arguments
+    /// * `address` - Destination Bitcoin address
+    /// * `spend` - An amount, or the whole wallet
+    /// * `fee_rate` - Fee rate for the transaction
+    /// * `coin_control` - Restrictions on which UTXOs fund the transaction
+    ///
+    /// # Returns
+    /// Transaction ID of the sent transaction
+    #[tracing::instrument(skip(self))]
+    pub async fn send_with_coin_control(
+        &self,
+        address: Address,
+        spend: Spend,
+        fee_rate: FeeRate,
+        coin_control: CoinControl,
+    ) -> Result<Txid> {
         let (tx, rx) = oneshot::channel();
         self.sender
-            .send(WalletCommand::SendToAddress(address, amount, fee_rate, tx))
+            .send(WalletCommand::Send {
+                address,
+                spend,
+                fee_rate,
+                coin_control,
+                responder: tx,
+            })
             .await?;
         rx.await.map_err(WalletError::Receiver)?
     }
@@ -684,11 +714,8 @@ impl DlcDevKitWallet {
     /// Transaction ID of the sent transaction
     #[tracing::instrument(skip(self))]
     pub async fn send_all(&self, address: Address, fee_rate: FeeRate) -> Result<Txid> {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(WalletCommand::SendAll(address, fee_rate, tx))
-            .await?;
-        rx.await.map_err(WalletError::Receiver)?
+        self.send_with_coin_control(address, Spend::All, fee_rate, CoinControl::default())
+            .await
     }
 
     /// Retrieves all transactions known to the wallet.
@@ -1228,6 +1255,63 @@ mod tests {
         // queued command.
         wallet.unreserve_utxos(&outpoints).unwrap();
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn coin_control_restricts_the_funding_utxos() {
+        use bitcoincore_rpc::RpcApi;
+
+        let wallet = create_wallet().await;
+        let addr_one = wallet.new_external_address().await.unwrap().address;
+        let addr_two = wallet.new_external_address().await.unwrap().address;
+        fund_address(&addr_one);
+        fund_address(&addr_two);
+        wallet.sync().await.unwrap();
+
+        let utxos = wallet.list_utxos().await.unwrap();
+        assert_eq!(utxos.len(), 2);
+        let selected = utxos[0].outpoint;
+        let excluded = utxos[1].outpoint;
+
+        // A manually selected UTXO is the only input of the send.
+        let dest = Address::from_str("bcrt1qt0yrvs7qx8guvpqsx8u9mypz6t4zr3pxthsjkm")
+            .unwrap()
+            .assume_checked();
+        let txid = wallet
+            .send_with_coin_control(
+                dest.clone(),
+                super::Spend::Amount(Amount::from_btc(0.5).unwrap()),
+                FeeRate::from_sat_per_vb(1).unwrap(),
+                super::CoinControl {
+                    selected_utxos: vec![selected],
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let env = ddk_testenv::env();
+        let tx = env.rpc().get_raw_transaction(&txid, None).unwrap();
+        assert_eq!(tx.input.len(), 1);
+        assert_eq!(tx.input[0].previous_output, selected);
+
+        // Let the wallet observe the spend so one coin remains.
+        env.wait_for_tx(&txid);
+        wallet.sync().await.unwrap();
+
+        // An unspendable outpoint never funds the send: only the other
+        // coin remains, so excluding it leaves nothing to spend.
+        let result = wallet
+            .send_with_coin_control(
+                dest,
+                super::Spend::Amount(Amount::from_btc(0.5).unwrap()),
+                FeeRate::from_sat_per_vb(1).unwrap(),
+                super::CoinControl {
+                    unspendable: vec![excluded],
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -162,6 +162,12 @@ pub enum WalletCommand {
         /// Channel for receiving the selected UTXOs
         responder: oneshot::Sender<Result<Vec<ddk_manager::Utxo>>>,
     },
+
+    /// Unlock previously locked outpoints and persist the change
+    UnlockOutpoints(
+        Vec<bitcoin::OutPoint>,
+        oneshot::Sender<Result<()>>,
+    ),
 }
 
 /// The main wallet implementation that provides Bitcoin functionality for DDK.
@@ -533,6 +539,26 @@ impl DlcDevKitWallet {
                             );
                         });
                     }
+                    WalletCommand::UnlockOutpoints(outpoints, responder) => {
+                        for outpoint in outpoints {
+                            wallet.unlock_outpoint(outpoint);
+                        }
+                        let result = wallet
+                            .persist_async(&mut storage)
+                            .await
+                            .map(|_| ())
+                            .map_err(|e| WalletError::WalletPersistanceError(e.to_string()));
+                        if let Err(e) = &result {
+                            log_error!(
+                                logger_clone,
+                                "Could not persist unlocked outpoints. error={:?}",
+                                e
+                            );
+                        }
+                        // The responder is already dropped when the manager
+                        // fires this command without waiting.
+                        let _ = responder.send(result);
+                    }
                 }
             }
         });
@@ -654,6 +680,17 @@ impl DlcDevKitWallet {
     pub async fn list_utxos(&self) -> Result<Vec<LocalOutput>> {
         let (tx, rx) = oneshot::channel();
         self.sender.send(WalletCommand::ListUtxos(tx)).await?;
+        rx.await.map_err(WalletError::Receiver)?
+    }
+
+    /// Unlocks previously locked outpoints and waits until the change is
+    /// persisted.
+    #[tracing::instrument(skip(self))]
+    pub async fn unlock_outpoints(&self, outpoints: Vec<bitcoin::OutPoint>) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::UnlockOutpoints(outpoints, tx))
+            .await?;
         rx.await.map_err(WalletError::Receiver)?
     }
 
@@ -819,13 +856,18 @@ impl ddk_manager::Wallet for DlcDevKitWallet {
         self.sign_psbt_input(psbt, input_index).await
     }
 
-    /// Unreserves UTXOs that were previously reserved for a transaction.
-    /// Currently a no-op as UTXO reservation is not implemented.
+    /// Unreserves UTXOs that were previously locked by coin selection.
+    /// The manager calls this when an offer fails or a contract is
+    /// rejected. The unlock command is fired without waiting because this
+    /// trait method is synchronous; the actor persists the change.
     fn unreserve_utxos(
         &self,
-        _outpoints: &[bitcoin::OutPoint],
+        outpoints: &[bitcoin::OutPoint],
     ) -> std::result::Result<(), ManagerError> {
-        Ok(())
+        let (tx, _rx) = oneshot::channel();
+        self.sender
+            .try_send(WalletCommand::UnlockOutpoints(outpoints.to_vec(), tx))
+            .map_err(|e| wallet_err_to_manager_err(WalletError::SendMessage(e.to_string())))
     }
 
     /// Imports an address into the wallet for monitoring.
@@ -1147,6 +1189,41 @@ mod tests {
 
         // Every coin is locked now: a third selection has nothing to spend.
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unlocked_outpoints_are_selectable_again() {
+        use ddk_manager::Wallet;
+
+        let wallet = create_wallet().await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        fund_address(&address);
+        wallet.sync().await.unwrap();
+
+        let amount = Amount::from_btc(0.5).unwrap();
+        let selected = wallet.get_utxos_for_amount(amount, 1, true).await.unwrap();
+        assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_err());
+
+        let outpoints = selected
+            .iter()
+            .map(|utxo| utxo.outpoint)
+            .collect::<Vec<_>>();
+        wallet.unlock_outpoints(outpoints.clone()).await.unwrap();
+
+        let reselected = wallet.get_utxos_for_amount(amount, 1, true).await.unwrap();
+        assert_eq!(
+            reselected
+                .iter()
+                .map(|utxo| utxo.outpoint)
+                .collect::<Vec<_>>(),
+            outpoints
+        );
+
+        // The synchronous manager path unlocks as well. It fires the
+        // command without waiting, so the effect lands with the next
+        // queued command.
+        wallet.unreserve_utxos(&outpoints).unwrap();
+        assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -30,7 +30,6 @@ use crate::logger::Logger;
 use crate::logger::{log_error, log_info, WriteLog};
 use crate::wallet::address::AddressGenerator;
 use crate::{chain::EsploraClient, Storage};
-use bdk_chain::Balance;
 use bdk_wallet::descriptor::IntoWalletDescriptor;
 use bdk_wallet::AsyncWalletPersister;
 pub use bdk_wallet::LocalOutput;
@@ -64,6 +63,24 @@ type Result<T> = std::result::Result<T, WalletError>;
 
 /// The minimum change size for the wallet to create in coin selection.
 const MIN_CHANGE_SIZE: u64 = 25_000;
+
+/// The wallet balance, split into the BDK balance categories plus the
+/// spendable/reserved view over the outpoint locks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WalletBalance {
+    /// Confirmed and mature coins
+    pub confirmed: Amount,
+    /// Unconfirmed coins from the wallet's own transactions
+    pub trusted_pending: Amount,
+    /// Unconfirmed coins from foreign transactions
+    pub untrusted_pending: Amount,
+    /// Immature coinbase outputs
+    pub immature: Amount,
+    /// Unspent coins minus reserved coins: what a new selection can spend
+    pub spendable: Amount,
+    /// Unspent coins locked for in-flight offers and funding transactions
+    pub reserved: Amount,
+}
 
 /// Wrapper type that adapts DDK's Storage trait to BDK's AsyncWalletPersister interface.
 ///
@@ -122,7 +139,7 @@ pub enum WalletCommand {
     Sync(oneshot::Sender<Result<()>>),
 
     /// Get the current wallet balance
-    Balance(oneshot::Sender<Balance>),
+    Balance(oneshot::Sender<WalletBalance>),
 
     /// Generate a new external (receiving) address
     NewExternalAddress(oneshot::Sender<Result<AddressInfo>>),
@@ -298,6 +315,23 @@ impl DlcDevKitWallet {
                     }
                     WalletCommand::Balance(sender) => {
                         let balance = wallet.balance();
+                        let reserved = wallet
+                            .list_unspent()
+                            .filter(|utxo| wallet.is_outpoint_locked(utxo.outpoint))
+                            .map(|utxo| utxo.txout.value)
+                            .sum::<Amount>();
+                        let spendable = balance
+                            .total()
+                            .checked_sub(reserved)
+                            .unwrap_or(Amount::ZERO);
+                        let balance = WalletBalance {
+                            confirmed: balance.confirmed,
+                            trusted_pending: balance.trusted_pending,
+                            untrusted_pending: balance.untrusted_pending,
+                            immature: balance.immature,
+                            spendable,
+                            reserved,
+                        };
                         let _ = sender.send(balance).map_err(|e| {
                             log_error!(
                                 logger_clone,
@@ -629,9 +663,11 @@ impl DlcDevKitWallet {
         PublicKey::from_secret_key(&self.secp, &self.xprv.private_key)
     }
 
-    /// Retrieves the current wallet balance including confirmed and unconfirmed amounts.
+    /// Retrieves the current wallet balance including confirmed and
+    /// unconfirmed amounts, plus the spendable/reserved split over the
+    /// outpoint locks.
     #[tracing::instrument(skip(self))]
-    pub async fn get_balance(&self) -> Result<Balance> {
+    pub async fn get_balance(&self) -> Result<WalletBalance> {
         let (tx, rx) = oneshot::channel();
         self.sender.send(WalletCommand::Balance(tx)).await?;
         rx.await.map_err(WalletError::Receiver)
@@ -1272,6 +1308,31 @@ mod tests {
         // queued command.
         wallet.unreserve_utxos(&outpoints).unwrap();
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn balance_splits_spendable_and_reserved() {
+        use ddk_manager::Wallet;
+
+        let wallet = create_wallet().await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        fund_address(&address);
+        wallet.sync().await.unwrap();
+
+        let before = wallet.get_balance().await.unwrap();
+        assert_eq!(before.reserved, Amount::ZERO);
+        assert_eq!(before.spendable, before.confirmed);
+
+        wallet
+            .get_utxos_for_amount(Amount::from_btc(0.5).unwrap(), 1, true)
+            .await
+            .unwrap();
+
+        // The single wallet coin is locked: it moves from spendable to
+        // reserved while the total stays the same.
+        let after = wallet.get_balance().await.unwrap();
+        assert_eq!(after.reserved, before.confirmed);
+        assert_eq!(after.spendable, Amount::ZERO);
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -63,8 +63,25 @@ use tokio::sync::{
 type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = std::result::Result<T, E>> + Send + 'a>>;
 type Result<T> = std::result::Result<T, WalletError>;
 
-/// The minimum change size for the wallet to create in coin selection.
-const MIN_CHANGE_SIZE: u64 = 25_000;
+/// The default minimum change size for the wallet to create in coin
+/// selection.
+pub const DEFAULT_MIN_CHANGE_SIZE: u64 = 25_000;
+
+/// Configuration of the internal BDK wallet.
+#[derive(Debug, Clone, Copy)]
+pub struct WalletConfig {
+    /// The smallest change output coin selection creates; a smaller
+    /// change amount goes to fees instead
+    pub min_change_size: u64,
+}
+
+impl Default for WalletConfig {
+    fn default() -> Self {
+        Self {
+            min_change_size: DEFAULT_MIN_CHANGE_SIZE,
+        }
+    }
+}
 
 /// The wallet balance, split into the BDK balance categories plus the
 /// spendable/reserved view over the outpoint locks.
@@ -289,6 +306,31 @@ impl DlcDevKitWallet {
         network: Network,
         storage: Arc<dyn Storage>,
         address_generator: Option<Arc<dyn AddressGenerator + Send + Sync>>,
+        logger: Arc<Logger>,
+    ) -> Result<DlcDevKitWallet> {
+        Self::new_with_config(
+            seed_bytes,
+            blockchain,
+            network,
+            storage,
+            address_generator,
+            WalletConfig::default(),
+            logger,
+        )
+        .await
+    }
+
+    /// Creates a new DlcDevKitWallet with an explicit [`WalletConfig`].
+    /// See [`DlcDevKitWallet::new`] for the construction steps.
+    #[tracing::instrument(name = "wallet", skip_all)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_config(
+        seed_bytes: &[u8; 64],
+        blockchain: Arc<EsploraClient>,
+        network: Network,
+        storage: Arc<dyn Storage>,
+        address_generator: Option<Arc<dyn AddressGenerator + Send + Sync>>,
+        config: WalletConfig,
         logger: Arc<Logger>,
     ) -> Result<DlcDevKitWallet> {
         let secp = Secp256k1::new();
@@ -549,6 +591,7 @@ impl DlcDevKitWallet {
                             amount,
                             fee_rate,
                             lock_utxos,
+                            config.min_change_size,
                         )
                         .await;
                         let _ = responder.send(result).map_err(|e| {
@@ -1309,6 +1352,45 @@ mod tests {
         // queued command.
         wallet.unreserve_utxos(&outpoints).unwrap();
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn custom_min_change_size_reaches_coin_selection() {
+        use ddk_manager::Wallet;
+
+        let esplora = ddk_testenv::env().esplora_host().to_string();
+        let logger = Arc::new(Logger::console(
+            "console_logger".to_string(),
+            LogLevel::Info,
+        ));
+        let esplora =
+            Arc::new(EsploraClient::new(&esplora, Network::Regtest, logger.clone()).unwrap());
+        let mut seed = [0u8; 64];
+        seed.try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+        let wallet = DlcDevKitWallet::new_with_config(
+            &seed,
+            esplora,
+            Network::Regtest,
+            Arc::new(MemoryStorage::new()),
+            None,
+            super::WalletConfig {
+                min_change_size: 1_000,
+            },
+            logger,
+        )
+        .await
+        .unwrap();
+
+        let address = wallet.new_external_address().await.unwrap().address;
+        fund_address(&address);
+        wallet.sync().await.unwrap();
+
+        let selected = wallet
+            .get_utxos_for_amount(Amount::from_btc(0.5).unwrap(), 1, false)
+            .await
+            .unwrap();
+        assert!(!selected.is_empty());
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -34,6 +34,7 @@ use crate::{chain::EsploraClient, Storage};
 use bdk_wallet::descriptor::IntoWalletDescriptor;
 use bdk_wallet::AsyncWalletPersister;
 pub use bdk_wallet::LocalOutput;
+pub use bdk_wallet::WalletEvent;
 use bdk_wallet::{
     bitcoin::{
         bip32::Xpriv,
@@ -216,6 +217,9 @@ pub enum WalletCommand {
 pub struct DlcDevKitWallet {
     /// Channel sender for wallet commands
     sender: Sender<WalletCommand>,
+    /// Broadcast sender for wallet events; new subscribers come from
+    /// [`DlcDevKitWallet::subscribe_events`]
+    events: tokio::sync::broadcast::Sender<WalletEvent>,
     /// Bitcoin network (mainnet, testnet, regtest)
     network: Network,
     /// Extended private key for the wallet
@@ -301,11 +305,13 @@ impl DlcDevKitWallet {
         let contract_keys = ContractKeyProvider::from_xprv(xprv);
 
         let (sender, mut receiver) = channel(100);
+        let (events, _) = tokio::sync::broadcast::channel(256);
 
         let mut tracker = contract_tracker::ContractUtxoTracker::from_changeset(
             storage.0.initialize_contract_tracker().await?,
         );
 
+        let events_clone = events.clone();
         let logger_clone = logger.clone();
         tokio::spawn(async move {
             while let Some(command) = receiver.recv().await {
@@ -316,6 +322,7 @@ impl DlcDevKitWallet {
                             &mut tracker,
                             &blockchain,
                             &mut storage,
+                            &events_clone,
                             logger_clone.clone(),
                         )
                         .await;
@@ -661,6 +668,7 @@ impl DlcDevKitWallet {
 
         Ok(DlcDevKitWallet {
             sender,
+            events,
             network,
             xprv,
             secp,
@@ -678,6 +686,13 @@ impl DlcDevKitWallet {
         let (tx, rx) = oneshot::channel();
         self.sender.send(WalletCommand::Sync(tx)).await?;
         rx.await.map_err(WalletError::Receiver)?
+    }
+
+    /// Subscribes to wallet events. Each sync emits an event for every
+    /// transaction that confirmed, unconfirmed, was replaced, or was
+    /// dropped, with reorg awareness from BDK.
+    pub fn subscribe_events(&self) -> tokio::sync::broadcast::Receiver<WalletEvent> {
+        self.events.subscribe()
     }
 
     /// Returns the wallet's master public key.
@@ -1342,6 +1357,26 @@ mod tests {
         // queued command.
         wallet.unreserve_utxos(&outpoints).unwrap();
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn emits_wallet_events_on_sync() {
+        let wallet = create_wallet().await;
+        let mut events = wallet.subscribe_events();
+        let address = wallet.new_external_address().await.unwrap().address;
+        wallet.sync().await.unwrap();
+        while events.try_recv().is_ok() {}
+
+        fund_address(&address);
+        wallet.sync().await.unwrap();
+
+        let mut confirmed = false;
+        while let Ok(event) = events.try_recv() {
+            if matches!(event, super::WalletEvent::TxConfirmed { .. }) {
+                confirmed = true;
+            }
+        }
+        assert!(confirmed);
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -931,13 +931,17 @@ mod tests {
 
     async fn create_wallet_from_seed(seed: &[u8; 64]) -> DlcDevKitWallet {
         let esplora = ddk_testenv::env().esplora_host().to_string();
+        create_wallet_on(&esplora, seed).await
+    }
+
+    async fn create_wallet_on(esplora: &str, seed: &[u8; 64]) -> DlcDevKitWallet {
         let storage = Arc::new(MemoryStorage::new());
         let logger = Arc::new(Logger::console(
             "console_logger".to_string(),
             LogLevel::Info,
         ));
         let esplora =
-            Arc::new(EsploraClient::new(&esplora, Network::Regtest, logger.clone()).unwrap());
+            Arc::new(EsploraClient::new(esplora, Network::Regtest, logger.clone()).unwrap());
         DlcDevKitWallet::new(
             seed,
             esplora,
@@ -1035,6 +1039,77 @@ mod tests {
         wallet.sync().await.unwrap();
         let pending = wallet.get_balance().await.unwrap().untrusted_pending;
         assert!(pending > Amount::ZERO);
+    }
+
+    #[tokio::test]
+    async fn drops_replaced_mempool_transaction() {
+        use bitcoincore_rpc::RpcApi;
+        use std::collections::HashMap;
+
+        // A private environment: a block mined by a concurrent test would
+        // confirm the transaction before it can be replaced.
+        let env = ddk_testenv::TestEnv::new();
+        let rpc = env.rpc();
+
+        let mut seed = [0u8; 64];
+        seed.try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+        let wallet = create_wallet_on(env.esplora_host(), &seed).await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        wallet.sync().await.unwrap();
+
+        // Build an RBF transaction that pays the wallet.
+        let unspent = rpc
+            .list_unspent(Some(1), None, None, None, None)
+            .unwrap()
+            .into_iter()
+            .find(|utxo| utxo.amount >= Amount::from_btc(1.0).unwrap() && utxo.spendable)
+            .unwrap();
+        let input = bitcoincore_rpc::json::CreateRawTransactionInput {
+            txid: unspent.txid,
+            vout: unspent.vout,
+            sequence: None,
+        };
+        let change = rpc.get_new_address(None, None).unwrap().assume_checked();
+        let payment = Amount::from_btc(0.5).unwrap();
+        let fee = Amount::from_sat(2_000);
+        let mut outputs = HashMap::new();
+        outputs.insert(address.to_string(), payment);
+        outputs.insert(change.to_string(), unspent.amount - payment - fee);
+        let raw = rpc
+            .create_raw_transaction(&[input.clone()], &outputs, None, Some(true))
+            .unwrap();
+        let signed = rpc
+            .sign_raw_transaction_with_wallet(&raw, None, None)
+            .unwrap();
+        let txid = rpc.send_raw_transaction(&signed.hex).unwrap();
+        env.wait_for_tx(&txid);
+
+        wallet.sync().await.unwrap();
+        assert_eq!(
+            wallet.get_balance().await.unwrap().untrusted_pending,
+            payment
+        );
+
+        // Replace it with a conflicting transaction that does not pay the
+        // wallet. The wallet only learns of the eviction from esplora.
+        let replacement_fee = Amount::from_sat(50_000);
+        let mut replacement_outputs = HashMap::new();
+        replacement_outputs.insert(change.to_string(), unspent.amount - replacement_fee);
+        let raw = rpc
+            .create_raw_transaction(&[input], &replacement_outputs, None, Some(true))
+            .unwrap();
+        let signed = rpc
+            .sign_raw_transaction_with_wallet(&raw, None, None)
+            .unwrap();
+        let replacement_txid = rpc.send_raw_transaction(&signed.hex).unwrap();
+        env.wait_for_tx(&replacement_txid);
+
+        wallet.sync().await.unwrap();
+        assert_eq!(
+            wallet.get_balance().await.unwrap().untrusted_pending,
+            Amount::ZERO
+        );
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -150,10 +150,9 @@ pub enum WalletCommand {
     /// Get the next derivation index for address generation
     NextDerivationIndex(oneshot::Sender<Result<u32>>),
 
-    /// Sign a specific input in a PSBT (Partially Signed Bitcoin Transaction)
-    SignPsbtInput(
+    /// Sign every wallet-owned input of a PSBT (Partially Signed Bitcoin Transaction)
+    SignPsbt(
         bitcoin::psbt::Psbt,
-        usize,
         oneshot::Sender<std::result::Result<Psbt, ManagerError>>,
     ),
 }
@@ -481,35 +480,29 @@ impl DlcDevKitWallet {
                             );
                         });
                     }
-                    WalletCommand::SignPsbtInput(mut psbt, input_index, sender) => {
+                    WalletCommand::SignPsbt(mut psbt, sender) => {
                         let sign_opts = SignOptions {
                             trust_witness_utxo: true,
                             ..Default::default()
                         };
-                        let mut signed_psbt = psbt.clone();
-                        if let Err(e) = wallet.sign(&mut signed_psbt, sign_opts) {
-                            log_error!(logger_clone, "Could not sign PSBT. error={:?}", e);
-                            let _ = sender
-                                .send(Err(ManagerError::WalletError(
-                                    WalletError::Signing(e).into(),
-                                )))
-                                .map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending sign psbt input command. error={:?}",
-                                        e
-                                    );
-                                });
-                        } else {
-                            psbt.inputs[input_index] = signed_psbt.inputs[input_index].clone();
-                            let _ = sender.send(Ok(psbt)).map_err(|e| {
-                                log_error!(
-                                    logger_clone,
-                                    "Error sending sign psbt input command. error={:?}",
-                                    e
-                                );
-                            });
-                        }
+                        // Sign in place, once, for every input the wallet
+                        // owns. A caller that walks a funding transaction
+                        // input-by-input finds later inputs already
+                        // finalized, so the signing work is done one time.
+                        let result = match wallet.sign(&mut psbt, sign_opts) {
+                            Ok(_) => Ok(psbt),
+                            Err(e) => {
+                                log_error!(logger_clone, "Could not sign PSBT. error={:?}", e);
+                                Err(ManagerError::WalletError(WalletError::Signing(e).into()))
+                            }
+                        };
+                        let _ = sender.send(result).map_err(|e| {
+                            log_error!(
+                                logger_clone,
+                                "Error sending sign psbt command. error={:?}",
+                                e
+                            );
+                        });
                     }
                 }
             }
@@ -638,7 +631,9 @@ impl DlcDevKitWallet {
     /// Signs a specific input in a PSBT for DLC operations.
     ///
     /// This method is used internally by the DLC manager to sign
-    /// DLC-related transactions such as funding transactions.
+    /// DLC-related transactions such as funding transactions. The manager
+    /// calls it once per input; the wallet signs the full PSBT on the first
+    /// call and later calls find their input already finalized.
     ///
     /// # Arguments
     /// * `psbt` - The PSBT to sign
@@ -649,9 +644,16 @@ impl DlcDevKitWallet {
         psbt: &mut bitcoin::psbt::Psbt,
         input_index: usize,
     ) -> std::result::Result<(), ManagerError> {
+        if psbt
+            .inputs
+            .get(input_index)
+            .is_some_and(|input| input.final_script_witness.is_some())
+        {
+            return Ok(());
+        }
         let (tx, rx) = oneshot::channel();
         self.sender
-            .send(WalletCommand::SignPsbtInput(psbt.clone(), input_index, tx))
+            .send(WalletCommand::SignPsbt(psbt.clone(), tx))
             .await
             .map_err(|e| ManagerError::WalletError(Box::new(WalletError::Sender(e))))?;
         let signed_psbt_received = rx

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -1015,6 +1015,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sees_mempool_transaction_without_new_block() {
+        // A private environment: a block mined by a concurrent test would
+        // change the chain height and confirm the transaction.
+        let env = ddk_testenv::TestEnv::new();
+        let mut seed = [0u8; 64];
+        seed.try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+        let wallet = create_wallet_on(env.esplora_host(), &seed).await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        // Bring the wallet tip up to the current chain height first.
+        wallet.sync().await.unwrap();
+
+        // Send to the address without mining a block: the transaction stays
+        // in the mempool and the chain height does not change.
+        let txid = env.send_to_address(&address, Amount::from_btc(0.5).unwrap());
+        env.wait_for_tx(&txid);
+
+        wallet.sync().await.unwrap();
+        let pending = wallet.get_balance().await.unwrap().untrusted_pending;
+        assert!(pending > Amount::ZERO);
+    }
+
+    #[tokio::test]
     async fn restore_from_seed_finds_change_outputs() {
         let mut seed = [0u8; 64];
         seed.try_fill(&mut bitcoin::key::rand::thread_rng())

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -190,6 +190,9 @@ pub enum WalletCommand {
 
     /// List the currently locked outpoints
     ListLockedOutpoints(oneshot::Sender<Vec<bitcoin::OutPoint>>),
+
+    /// List the tracked contract funding outputs with their chain state
+    ContractUtxos(oneshot::Sender<Vec<contract_tracker::ContractUtxo>>),
 }
 
 /// The main wallet implementation that provides Bitcoin functionality for DDK.
@@ -642,6 +645,16 @@ impl DlcDevKitWallet {
                             );
                         });
                     }
+                    WalletCommand::ContractUtxos(responder) => {
+                        let utxos = tracker.utxos(wallet.local_chain());
+                        let _ = responder.send(utxos).map_err(|e| {
+                            log_error!(
+                                logger_clone,
+                                "Error sending contract utxos command. error={:?}",
+                                e
+                            );
+                        });
+                    }
                 }
             }
         });
@@ -786,6 +799,16 @@ impl DlcDevKitWallet {
         self.sender
             .send(WalletCommand::ListLockedOutpoints(tx))
             .await?;
+        rx.await.map_err(WalletError::Receiver)
+    }
+
+    /// Lists the tracked contract funding outputs with their chain state,
+    /// so a consumer can show locked collateral per contract and observe
+    /// a close.
+    #[tracing::instrument(skip(self))]
+    pub async fn contract_utxos(&self) -> Result<Vec<contract_tracker::ContractUtxo>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender.send(WalletCommand::ContractUtxos(tx)).await?;
         rx.await.map_err(WalletError::Receiver)
     }
 

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -393,61 +393,16 @@ impl DlcDevKitWallet {
                         });
                     }
                     WalletCommand::SendToAddress(address, amount, fee_rate, sender) => {
-                        let mut txn_builder = wallet.build_tx();
-                        txn_builder
-                            .add_recipient(address.script_pubkey(), amount)
-                            .version(2)
-                            .fee_rate(fee_rate);
-                        let mut psbt = match txn_builder.finish() {
-                            Ok(psbt) => psbt,
-                            Err(e) => {
-                                let _ = sender.send(Err(WalletError::TxnBuilder(e))).map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending send to address command. error={:?}",
-                                        e
-                                    );
-                                });
-                                continue;
-                            }
-                        };
-                        if let Err(e) = wallet.sign(&mut psbt, SignOptions::default()) {
-                            let _ = sender.send(Err(WalletError::Signing(e))).map_err(|e| {
-                                log_error!(
-                                    logger_clone,
-                                    "Error sending send to address command. error={:?}",
-                                    e
-                                );
-                            });
-                            continue;
-                        }
-                        let tx = match psbt.extract_tx() {
-                            Ok(tx) => tx,
-                            Err(_) => {
-                                let _ = sender.send(Err(WalletError::ExtractTx)).map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending send to address command. error={:?}",
-                                        e
-                                    );
-                                });
-                                continue;
-                            }
-                        };
-                        let txid = tx.compute_txid();
-                        if let Err(e) = blockchain.async_client.broadcast(&tx).await {
-                            let _ = sender
-                                .send(Err(WalletError::Esplora(e.to_string())))
-                                .map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending send to address command. error={:?}",
-                                        e
-                                    );
-                                });
-                            continue;
-                        }
-                        let _ = sender.send(Ok(txid)).map_err(|e| {
+                        let result = command::send(
+                            &mut wallet,
+                            &blockchain,
+                            &mut storage,
+                            address,
+                            command::Spend::Amount(amount),
+                            fee_rate,
+                        )
+                        .await;
+                        let _ = sender.send(result).map_err(|e| {
                             log_error!(
                                 logger_clone,
                                 "Error sending send to address command. error={:?}",
@@ -456,60 +411,16 @@ impl DlcDevKitWallet {
                         });
                     }
                     WalletCommand::SendAll(address, fee_rate, sender) => {
-                        let mut tx_builder = wallet.build_tx();
-                        tx_builder.fee_rate(fee_rate);
-                        tx_builder.drain_wallet();
-                        tx_builder.drain_to(address.script_pubkey());
-                        let mut psbt = match tx_builder.finish() {
-                            Ok(psbt) => psbt,
-                            Err(e) => {
-                                let _ = sender.send(Err(WalletError::TxnBuilder(e))).map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending send all command. error={:?}",
-                                        e
-                                    );
-                                });
-                                continue;
-                            }
-                        };
-                        if let Err(e) = wallet.sign(&mut psbt, SignOptions::default()) {
-                            let _ = sender.send(Err(WalletError::Signing(e))).map_err(|e| {
-                                log_error!(
-                                    logger_clone,
-                                    "Error sending send all command. error={:?}",
-                                    e
-                                );
-                            });
-                            continue;
-                        }
-                        let tx = match psbt.extract_tx() {
-                            Ok(tx) => tx,
-                            Err(_) => {
-                                let _ = sender.send(Err(WalletError::ExtractTx)).map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending send all command. error={:?}",
-                                        e
-                                    );
-                                });
-                                continue;
-                            }
-                        };
-                        let txid = tx.compute_txid();
-                        if let Err(e) = blockchain.async_client.broadcast(&tx).await {
-                            let _ = sender
-                                .send(Err(WalletError::Esplora(e.to_string())))
-                                .map_err(|e| {
-                                    log_error!(
-                                        logger_clone,
-                                        "Error sending send all command. error={:?}",
-                                        e
-                                    );
-                                });
-                            continue;
-                        }
-                        let _ = sender.send(Ok(txid)).map_err(|e| {
+                        let result = command::send(
+                            &mut wallet,
+                            &blockchain,
+                            &mut storage,
+                            address,
+                            command::Spend::All,
+                            fee_rate,
+                        )
+                        .await;
+                        let _ = sender.send(result).map_err(|e| {
                             log_error!(
                                 logger_clone,
                                 "Error sending send all command. error={:?}",

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -168,6 +168,16 @@ pub enum WalletCommand {
         responder: oneshot::Sender<Result<Txid>>,
     },
 
+    /// Replace an unconfirmed wallet transaction with a higher-fee version
+    BumpFee {
+        /// The transaction to replace
+        txid: Txid,
+        /// The fee rate of the replacement; must beat the original's
+        fee_rate: FeeRate,
+        /// Channel for receiving the replacement transaction id
+        responder: oneshot::Sender<Result<Txid>>,
+    },
+
     /// Get all wallet transactions
     GetTransactions(oneshot::Sender<Result<Vec<Arc<Transaction>>>>),
 
@@ -422,6 +432,27 @@ impl DlcDevKitWallet {
                         .await;
                         let _ = responder.send(result).map_err(|e| {
                             log_error!(logger_clone, "Error sending send command. error={:?}", e);
+                        });
+                    }
+                    WalletCommand::BumpFee {
+                        txid,
+                        fee_rate,
+                        responder,
+                    } => {
+                        let result = command::bump_fee(
+                            &mut wallet,
+                            &blockchain,
+                            &mut storage,
+                            txid,
+                            fee_rate,
+                        )
+                        .await;
+                        let _ = responder.send(result).map_err(|e| {
+                            log_error!(
+                                logger_clone,
+                                "Error sending bump fee command. error={:?}",
+                                e
+                            );
                         });
                     }
                     WalletCommand::GetTransactions(sender) => {
@@ -716,6 +747,29 @@ impl DlcDevKitWallet {
     pub async fn send_all(&self, address: Address, fee_rate: FeeRate) -> Result<Txid> {
         self.send_with_coin_control(address, Spend::All, fee_rate, CoinControl::default())
             .await
+    }
+
+    /// Replaces a stuck unconfirmed wallet transaction with a
+    /// higher-fee version (RBF is on by default for wallet
+    /// transactions).
+    ///
+    /// # Arguments
+    /// * `txid` - The transaction to replace; it must be unconfirmed
+    /// * `fee_rate` - Fee rate of the replacement; must beat the original's
+    ///
+    /// # Returns
+    /// Transaction ID of the replacement transaction
+    #[tracing::instrument(skip(self))]
+    pub async fn bump_fee(&self, txid: Txid, fee_rate: FeeRate) -> Result<Txid> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(WalletCommand::BumpFee {
+                txid,
+                fee_rate,
+                responder: tx,
+            })
+            .await?;
+        rx.await.map_err(WalletError::Receiver)?
     }
 
     /// Retrieves all transactions known to the wallet.
@@ -1255,6 +1309,49 @@ mod tests {
         // queued command.
         wallet.unreserve_utxos(&outpoints).unwrap();
         assert!(wallet.get_utxos_for_amount(amount, 1, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn bump_fee_replaces_a_stuck_transaction() {
+        use bitcoincore_rpc::RpcApi;
+
+        // A private environment: a block mined by a concurrent test would
+        // confirm the transaction before it can be replaced.
+        let env = ddk_testenv::TestEnv::new();
+        let mut seed = [0u8; 64];
+        seed.try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+        let wallet = create_wallet_on(env.esplora_host(), &seed).await;
+        let address = wallet.new_external_address().await.unwrap().address;
+        env.fund_address(&address, Amount::from_btc(1.0).unwrap());
+        wallet.sync().await.unwrap();
+
+        let dest = Address::from_str("bcrt1qt0yrvs7qx8guvpqsx8u9mypz6t4zr3pxthsjkm")
+            .unwrap()
+            .assume_checked();
+        let txid = wallet
+            .send_to_address(
+                dest,
+                Amount::from_btc(0.5).unwrap(),
+                FeeRate::from_sat_per_vb(1).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // The wallet has to see its unconfirmed transaction to replace it.
+        env.wait_for_tx(&txid);
+        wallet.sync().await.unwrap();
+
+        let replacement = wallet
+            .bump_fee(txid, FeeRate::from_sat_per_vb(10).unwrap())
+            .await
+            .unwrap();
+        assert_ne!(replacement, txid);
+
+        // The replacement is in the mempool and the original is gone.
+        let rpc = env.rpc();
+        assert!(rpc.get_mempool_entry(&replacement).is_ok());
+        assert!(rpc.get_mempool_entry(&txid).is_err());
     }
 
     #[tokio::test]

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -81,6 +81,10 @@ pub struct WalletBalance {
     pub spendable: Amount,
     /// Unspent coins locked for in-flight offers and funding transactions
     pub reserved: Amount,
+    /// Confirmed contract funding outputs, from chain truth
+    pub contract_confirmed: Amount,
+    /// Unconfirmed contract funding outputs, from chain truth
+    pub contract_pending: Amount,
 }
 
 /// Wrapper type that adapts DDK's Storage trait to BDK's AsyncWalletPersister interface.
@@ -325,6 +329,7 @@ impl DlcDevKitWallet {
                             .total()
                             .checked_sub(reserved)
                             .unwrap_or(Amount::ZERO);
+                        let contract_balance = tracker.balance(wallet.local_chain());
                         let balance = WalletBalance {
                             confirmed: balance.confirmed,
                             trusted_pending: balance.trusted_pending,
@@ -332,6 +337,9 @@ impl DlcDevKitWallet {
                             immature: balance.immature,
                             spendable,
                             reserved,
+                            contract_confirmed: contract_balance.confirmed,
+                            contract_pending: contract_balance.trusted_pending
+                                + contract_balance.untrusted_pending,
                         };
                         let _ = sender.send(balance).map_err(|e| {
                             log_error!(

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -23,6 +23,7 @@
 
 pub mod address;
 mod command;
+pub mod contract_tracker;
 
 use crate::contract::ContractKeyProvider;
 use crate::error::{wallet_err_to_manager_err, WalletError};
@@ -181,10 +182,7 @@ pub enum WalletCommand {
     },
 
     /// Unlock previously locked outpoints and persist the change
-    UnlockOutpoints(
-        Vec<bitcoin::OutPoint>,
-        oneshot::Sender<Result<()>>,
-    ),
+    UnlockOutpoints(Vec<bitcoin::OutPoint>, oneshot::Sender<Result<()>>),
 
     /// List the currently locked outpoints
     ListLockedOutpoints(oneshot::Sender<Vec<bitcoin::OutPoint>>),

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -929,7 +929,7 @@ mod tests {
 
     use super::DlcDevKitWallet;
 
-    async fn create_wallet() -> DlcDevKitWallet {
+    async fn create_wallet_from_seed(seed: &[u8; 64]) -> DlcDevKitWallet {
         let esplora = ddk_testenv::env().esplora_host().to_string();
         let storage = Arc::new(MemoryStorage::new());
         let logger = Arc::new(Logger::console(
@@ -938,12 +938,8 @@ mod tests {
         ));
         let esplora =
             Arc::new(EsploraClient::new(&esplora, Network::Regtest, logger.clone()).unwrap());
-        let mut entropy = [0u8; 64];
-        entropy
-            .try_fill(&mut bitcoin::key::rand::thread_rng())
-            .unwrap();
         DlcDevKitWallet::new(
-            &entropy,
+            seed,
             esplora,
             Network::Regtest,
             storage.clone(),
@@ -952,6 +948,14 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    async fn create_wallet() -> DlcDevKitWallet {
+        let mut entropy = [0u8; 64];
+        entropy
+            .try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+        create_wallet_from_seed(&entropy).await
     }
 
     fn generate_blocks(num: u64) {
@@ -1008,6 +1012,43 @@ mod tests {
         wallet.sync().await.unwrap();
         let balance = wallet.get_balance().await.unwrap();
         assert!(balance.confirmed == Amount::ZERO)
+    }
+
+    #[tokio::test]
+    async fn restore_from_seed_finds_change_outputs() {
+        let mut seed = [0u8; 64];
+        seed.try_fill(&mut bitcoin::key::rand::thread_rng())
+            .unwrap();
+
+        let original = create_wallet_from_seed(&seed).await;
+        let addr = original.new_external_address().await.unwrap().address;
+        fund_address(&addr);
+        original.sync().await.unwrap();
+
+        // Spend to a foreign address so the only remaining funds sit on an
+        // internal (change) output.
+        let dest = Address::from_str("bcrt1qt0yrvs7qx8guvpqsx8u9mypz6t4zr3pxthsjkm")
+            .unwrap()
+            .assume_checked();
+        original
+            .send_to_address(
+                dest,
+                Amount::from_sat(10_000_000),
+                FeeRate::from_sat_per_vb(1).unwrap(),
+            )
+            .await
+            .unwrap();
+        generate_blocks(1);
+        original.sync().await.unwrap();
+        let original_balance = original.get_balance().await.unwrap();
+        assert!(original_balance.confirmed > Amount::ZERO);
+
+        // Restore from the same seed into empty storage. The full scan must
+        // discover the used change address on the internal keychain.
+        let restored = create_wallet_from_seed(&seed).await;
+        restored.sync().await.unwrap();
+        let restored_balance = restored.get_balance().await.unwrap();
+        assert_eq!(restored_balance.confirmed, original_balance.confirmed);
     }
 
     #[tokio::test]

--- a/ddk/tests/enumeration.rs
+++ b/ddk/tests/enumeration.rs
@@ -291,4 +291,34 @@ async fn enumeration_contract() {
     let balance = bob.ddk.balance().await.unwrap();
     assert_eq!(balance.contract_confirmed, Amount::ZERO);
     assert_eq!(balance.contract_pending, Amount::ZERO);
+
+    // The contract auto-labeled its transactions: the funding tx and
+    // outpoint carry the contract id, the CET carries the outcome, and
+    // the labels survive a JSONL export/import round trip.
+    let labels = bob.ddk.labels().await.unwrap();
+    let funding_txid = contract_utxos[0].outpoint.txid;
+    let cet_txid = contract_utxos[0].spent_by.unwrap();
+    assert!(labels.iter().any(|label| matches!(
+        label,
+        ddk::bip329::Label::Transaction(record)
+            if record.ref_ == funding_txid
+                && record.label.as_deref().unwrap_or_default().starts_with("DLC funding")
+    )));
+    assert!(labels.iter().any(|label| matches!(
+        label,
+        ddk::bip329::Label::Output(record) if record.ref_ == contract_utxos[0].outpoint
+    )));
+    assert!(labels.iter().any(|label| matches!(
+        label,
+        ddk::bip329::Label::Transaction(record)
+            if record.ref_ == cet_txid
+                && record.label.as_deref().unwrap_or_default().contains("rust")
+    )));
+
+    let exported = bob.ddk.export_labels().await.unwrap();
+    bob.ddk.import_labels(&exported).await.unwrap();
+    assert_eq!(
+        bob.ddk.labels().await.unwrap().iter().count(),
+        labels.iter().count()
+    );
 }

--- a/ddk/tests/enumeration.rs
+++ b/ddk/tests/enumeration.rs
@@ -187,6 +187,20 @@ async fn enumeration_contract() {
     bob.ddk.wallet.sync().await.unwrap();
     alice.ddk.wallet.sync().await.unwrap();
 
+    // The tracker sees the confirmed 2-of-2 funding output on both sides.
+    for party in [&alice, &bob] {
+        let contract_utxos = party.ddk.contract_utxos().await.unwrap();
+        assert_eq!(contract_utxos.len(), 1);
+        assert_eq!(contract_utxos[0].contract_id, contract_id);
+        assert!(contract_utxos[0].confirmed);
+        assert_eq!(contract_utxos[0].spent_by, None);
+        assert!(contract_utxos[0].txout.value >= Amount::from_sat(100_000));
+
+        let balance = party.ddk.balance().await.unwrap();
+        assert_eq!(balance.contract_confirmed, contract_utxos[0].txout.value);
+        assert_eq!(balance.contract_pending, Amount::ZERO);
+    }
+
     // Used to check that timelock is reached.
     let locktime = match alice.ddk.storage.get_contract(&contract_id).await.unwrap() {
         Some(contract) => match contract {
@@ -267,4 +281,14 @@ async fn enumeration_contract() {
 
     // Serialize Closed state
     assert_contract_state_and_serialize!(bob.ddk.storage, contract_id, Closed);
+
+    // The CET spent the funding output: the tracker observes the close
+    // and the chain-truth contract balance returns to zero.
+    bob.ddk.wallet.sync().await.unwrap();
+    let contract_utxos = bob.ddk.contract_utxos().await.unwrap();
+    assert_eq!(contract_utxos.len(), 1);
+    assert!(contract_utxos[0].spent_by.is_some());
+    let balance = bob.ddk.balance().await.unwrap();
+    assert_eq!(balance.contract_confirmed, Amount::ZERO);
+    assert_eq!(balance.contract_pending, Amount::ZERO);
 }


### PR DESCRIPTION
## Summary
Implements all five phases of `docs/wallet-improvement-plan.md`, one commit per plan item: sync correctness fixes, persistent UTXO reservation with BDK outpoint locking, chain-truth tracking of contract funding outputs, wallet events with live fee estimation, and BIP-329 labels with coin control.

Stacked on `postgres-storage-fixes` (#178); merge after it.

## Changes

**Phase 1 — correctness**
- Full scan covers both keychains (stop gap 50, five parallel requests), so a wallet restored from seed finds its change outputs
- Sync always runs instead of short-circuiting on an unchanged tip height, so mempool transactions are visible without a new block
- Syncs seed esplora with expected txids, so replaced or evicted transactions drop out of the canonical view and a stuck pending balance recovers
- Incremental syncs no longer fabricate last-active derivation indices
- `bdk_wallet` manifest floor raised to 3.1.0
- The funding PSBT is signed in place once; later per-input calls find their input already finalized

**Phase 2 — UTXO reservation**
- Coin selection runs in the wallet actor, skips locked outpoints, and locks the selection when the manager asks, so concurrent offers cannot pick the same coins
- `unreserve_utxos` unlocks through BDK instead of being a no-op
- Postgres persists `locked_outpoints` (new migration); sled and memory already round-trip the field
- Wallet-owned inputs of a signed funding PSBT lock at sign time and unlock when a confirmed transaction spends them
- `crate::Balance` reports `spendable` (unspent minus locked) and `reserved` (locked)

**Phase 3 — contract UTXO tracker**
- `ContractUtxoTracker`: an `SpkTxOutIndex<ContractId>` over its own `TxGraph`, sharing the wallet's local chain view
- Each sync registers funding scripts from contract storage and runs a second targeted sync over the funding SPKs and outpoints, learning confirmation and any spend (CET, refund, counterparty close) in one round trip
- `contract_confirmed`/`contract_pending` come from `TxGraph::balance()` over the tracked outpoints instead of collateral math; PnL stays from contract state
- The tracker changeset persists through the `Storage` trait in memory, sled, and postgres (new migration), with no-op defaults for external backends
- `contract_utxos()` on the wallet and DDK API lists locked collateral per contract

**Phase 4 — events and fees**
- Syncs apply updates via `apply_update_events`; `WalletEvent`s forward on a broadcast channel and transaction events trigger the manager's periodic check immediately
- Esplora fee estimates fill a per-target cache each sync; the old constants stay as floors/fallback, and every `ConfirmationTarget` now has an entry (the old map panicked on `MaximumFeeEstimate` and `OutputSpendingFee`)
- `SendToAddress`/`SendAll` share one build-sign-broadcast helper that also persists the revealed change index

**Phase 5 — labels and coin control**
- BIP-329 labels via the `bip329` crate, stored through the `Storage` trait in all three backends (new migration), keyed by record type plus reference
- Contracts auto-label their funding transaction, funding outpoint, and CET (with the attested outcome); labels export/import as JSONL
- `send_with_coin_control`: caller-selected UTXOs, an unspendable list, and a confirmation floor
- `bump_fee` replaces a stuck unconfirmed send via RBF
- The 25 000 sat minimum change size is a `WalletConfig`/builder option

## Testing
- `cargo test -p ddk --features "sled,postgres" --lib`: 83 tests pass, including new tests for restore-from-seed, mempool visibility, RBF eviction, concurrent selection, lock restart survival, sign-time locking, balance split, tracker unit tests, storage round trips, fee cache, events, labels, coin control, and fee bumping
- End-to-end contract tests pass: `cargo test -p ddk --test enumeration -- --ignored` (now also asserts tracker state, chain-truth balance, and auto-labels through settlement) and `cargo test -p ddk --test short_call -- --ignored`
- `cargo clippy -p ddk --all-features` shows only pre-existing warnings in untouched oracle files
