### PR TITLE
manager: tell apart missing transactions from mempool transactions

### DIFF
--- a/ddk-manager/src/lib.rs
+++ b/ddk-manager/src/lib.rs
@@ -174,6 +174,35 @@ pub trait Wallet {
     fn unreserve_utxos(&self, outpoints: &[OutPoint]) -> Result<(), Error>;
 }
 
+/// The state of a transaction on the bitcoin network, as reported by
+/// [`Blockchain::get_transaction_confirmations`].
+///
+/// This tells apart a transaction that sits in the mempool with zero
+/// confirmations from a transaction the network does not know at all
+/// (never broadcast, or evicted from the mempool).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfirmationStatus {
+    /// The transaction is not in the mempool and not in a block. It was
+    /// either never broadcast or it was evicted from the mempool.
+    NotFound,
+    /// The transaction is in the mempool and has zero confirmations.
+    InMempool,
+    /// The transaction is included in a block and has the given number of
+    /// confirmations.
+    Confirmed(u32),
+}
+
+impl ConfirmationStatus {
+    /// The number of confirmations. A transaction that is not found or that
+    /// only sits in the mempool has zero confirmations.
+    pub fn confirmations(&self) -> u32 {
+        match self {
+            ConfirmationStatus::Confirmed(confirmations) => *confirmations,
+            ConfirmationStatus::NotFound | ConfirmationStatus::InMempool => 0,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 /// Blockchain trait provides access to the bitcoin blockchain.
 pub trait Blockchain {
@@ -187,8 +216,11 @@ pub trait Blockchain {
     async fn get_block_at_height(&self, height: u64) -> Result<Block, Error>;
     /// Get the transaction with given id.
     async fn get_transaction(&self, tx_id: &Txid) -> Result<Transaction, Error>;
-    /// Get the number of confirmation for the transaction with given id.
-    async fn get_transaction_confirmations(&self, tx_id: &Txid) -> Result<u32, Error>;
+    /// Get the confirmation status of the transaction with the given id.
+    async fn get_transaction_confirmations(
+        &self,
+        tx_id: &Txid,
+    ) -> Result<ConfirmationStatus, Error>;
 }
 
 #[async_trait::async_trait]

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -1,7 +1,8 @@
 //! #Manager a component to create and update DLCs.
 
 use super::{
-    Blockchain, CachedContractSignerProvider, ContractSigner, Oracle, Storage, Time, Wallet,
+    Blockchain, CachedContractSignerProvider, ConfirmationStatus, ContractSigner, Oracle, Storage,
+    Time, Wallet,
 };
 use crate::chain_monitor::{ChainMonitor, ChannelInfo, RevokedTxType, TxType};
 use crate::channel::offered_channel::OfferedChannel;
@@ -821,16 +822,24 @@ where
 
     #[tracing::instrument(skip_all, level = "debug")]
     async fn check_signed_contract(&self, contract: &SignedContract) -> Result<(), Error> {
-        let confirmations = self
+        let fund_txid = contract
+            .accepted_contract
+            .dlc_transactions
+            .fund
+            .compute_txid();
+        let status = self
             .blockchain
-            .get_transaction_confirmations(
-                &contract
-                    .accepted_contract
-                    .dlc_transactions
-                    .fund
-                    .compute_txid(),
-            )
+            .get_transaction_confirmations(&fund_txid)
             .await?;
+        if status == ConfirmationStatus::NotFound {
+            log_warn!(self.logger,
+                "Funding transaction not found in mempool or on-chain. Not confirming contract. fund_txid={} contract_id={}",
+                fund_txid.to_string(),
+                contract.accepted_contract.get_contract_id_string(),
+            );
+            return Ok(());
+        }
+        let confirmations = status.confirmations();
         if confirmations >= *NB_CONFIRMATIONS {
             log_info!(
                 self.logger,
@@ -904,12 +913,36 @@ where
                 }
                 Err(e) => {
                     log_debug!(self.logger,
-                        "The previouse contract referenced in a splice transaction failed to retrieve. contract_id={} error={}", 
+                        "The previouse contract referenced in a splice transaction failed to retrieve. contract_id={} error={}",
                         contract_id.to_lower_hex_string(), e.to_string(),
                     );
                     Err(e)
                 }
             }?;
+
+            // The funding transaction of the splice contract closes the
+            // previous contract. Only pre-close the previous contract when
+            // the network knows that transaction. A transaction that was
+            // evicted from the mempool, or that was not broadcast, must not
+            // close the previous contract.
+            let splice_fund_txid = contract
+                .accepted_contract
+                .dlc_transactions
+                .fund
+                .compute_txid();
+            if self
+                .blockchain
+                .get_transaction_confirmations(&splice_fund_txid)
+                .await?
+                == ConfirmationStatus::NotFound
+            {
+                log_debug!(self.logger,
+                    "Splice funding transaction not found in mempool or on-chain. Not pre-closing the previous contract. splice_fund_txid={} contract_id={}",
+                    splice_fund_txid.to_string(),
+                    contract_id.to_lower_hex_string(),
+                );
+                continue;
+            }
 
             let preclosed_contract = PreClosedContract {
                 signed_contract: confirmed_contract_in_splice.clone(),
@@ -1116,10 +1149,17 @@ where
             .dlc_transactions
             .pending_close_txs
         {
-            let confirmations = self
+            let status = self
                 .blockchain
                 .get_transaction_confirmations(&pending_close_tx.compute_txid())
                 .await?;
+            if status == ConfirmationStatus::NotFound {
+                // The pending close transaction is not in the mempool and not
+                // in a block. It was not broadcast, or it was evicted from
+                // the mempool. Do not close the contract with it.
+                continue;
+            }
+            let confirmations = status.confirmations();
 
             log_debug!(
                 self.logger,
@@ -1129,7 +1169,11 @@ where
                 confirmations
             );
 
-            if confirmations >= *NB_CONFIRMATIONS {
+            // `Closed` is a terminal state that no periodic check examines
+            // again. A transaction that only sits in the mempool can still be
+            // evicted, so require at least one confirmation on-chain, also
+            // when `NB_CONFIRMATIONS` is zero.
+            if confirmations >= (*NB_CONFIRMATIONS).max(1) {
                 // Found a fully confirmed pending close - move directly to Closed
                 log_info!(self.logger,
                     "Pending close transaction is fully confirmed. Moving to closed. close_txid={} contract_id={}", 
@@ -1298,10 +1342,44 @@ where
     #[tracing::instrument(skip_all, level = "debug")]
     async fn check_preclosed_contract(&self, contract: &PreClosedContract) -> Result<(), Error> {
         let broadcasted_txid = contract.signed_cet.compute_txid();
-        let confirmations = self
+        let status = self
             .blockchain
             .get_transaction_confirmations(&broadcasted_txid)
             .await?;
+        if status == ConfirmationStatus::NotFound {
+            // The closing transaction is not in the mempool and not in a
+            // block. It was evicted from the mempool, or the chain source has
+            // not seen it yet. Broadcast it again — the network accepts a
+            // transaction it already knows without an error.
+            match self.blockchain.send_transaction(&contract.signed_cet).await {
+                Ok(()) => {
+                    log_warn!(self.logger,
+                        "Closing transaction not found in mempool or on-chain. Broadcast it again. close_txid={} contract_id={}",
+                        broadcasted_txid.to_string(),
+                        contract.signed_contract.accepted_contract.get_contract_id_string(),
+                    );
+                }
+                Err(e) if contract.attestations.is_none() => {
+                    // A pre-close without attestations comes from a splice or
+                    // a cooperative close. Its closing transaction cannot
+                    // enter the mempool again, so the funding output stays
+                    // unspent and the contract is still live. Move it back to
+                    // confirmed.
+                    log_warn!(self.logger,
+                        "Closing transaction was dropped and cannot be broadcast again. Moving contract back to confirmed. close_txid={} contract_id={} error={}",
+                        broadcasted_txid.to_string(),
+                        contract.signed_contract.accepted_contract.get_contract_id_string(),
+                        e.to_string(),
+                    );
+                    self.store
+                        .update_contract(&Contract::Confirmed(contract.signed_contract.clone()))
+                        .await?;
+                }
+                Err(e) => return Err(e),
+            }
+            return Ok(());
+        }
+        let confirmations = status.confirmations();
         log_debug!(
             self.logger,
             "Checking pre-closed contract. broadcasted_txid={} contract_id={} confirmations={}",
@@ -1312,9 +1390,13 @@ where
                 .get_contract_id_string(),
             confirmations
         );
-        if confirmations >= *NB_CONFIRMATIONS {
+        // `Closed` is a terminal state that no periodic check examines again.
+        // A transaction that only sits in the mempool can still be evicted,
+        // so require at least one confirmation on-chain, also when
+        // `NB_CONFIRMATIONS` is zero.
+        if confirmations >= (*NB_CONFIRMATIONS).max(1) {
             log_debug!(self.logger,
-                "Pre-closed contract is fully confirmed. Moving to closed. broadcasted_txid={} contract_id={}", 
+                "Pre-closed contract is fully confirmed. Moving to closed. broadcasted_txid={} contract_id={}",
                 broadcasted_txid.to_string(),
                 contract.signed_contract.accepted_contract.get_contract_id_string()
             );
@@ -1361,10 +1443,13 @@ where
         signed_cet: Transaction,
         attestations: Vec<OracleAttestation>,
     ) -> Result<Contract, Error> {
+        // A CET that was not broadcast yet is not found on the network, so
+        // count it as zero confirmations.
         let confirmations = self
             .blockchain
             .get_transaction_confirmations(&signed_cet.compute_txid())
-            .await?;
+            .await?
+            .confirmations();
 
         if confirmations < 1 {
             log_info!(
@@ -1443,10 +1528,13 @@ where
             );
             let accepted_contract = &contract.accepted_contract;
             let refund = accepted_contract.dlc_transactions.refund.clone();
+            // A refund that was not broadcast yet is not found on the
+            // network, so count it as zero confirmations.
             let confirmations = self
                 .blockchain
                 .get_transaction_confirmations(&refund.compute_txid())
-                .await?;
+                .await?
+                .confirmations();
             if confirmations == 0 {
                 log_debug!(self.logger,
                     "Refund transaction has not been broadcast yet. Sending transaction txid={} contract_id={}", 
@@ -1492,7 +1580,8 @@ where
             let confirmations = self
                 .blockchain
                 .get_transaction_confirmations(&refund_txid)
-                .await?;
+                .await?
+                .confirmations();
 
             if confirmations > 0 {
                 // Counterparty (or we) already broadcast the refund tx. Update state.
@@ -2142,6 +2231,7 @@ where
             .blockchain
             .get_transaction_confirmations(&buffer_tx.compute_txid())
             .await?
+            .confirmations()
             >= CET_NSEQUENCE
         {
             log_info!(
@@ -3441,7 +3531,7 @@ where
             .blockchain
             .get_transaction_confirmations(&settle_tx.compute_txid())
             .await
-            .unwrap_or(0)
+            .map_or(0, |status| status.confirmations())
             == 0
         {
             self.blockchain.send_transaction(&settle_tx).await?;

--- a/ddk-manager/tests/manager_execution_tests.rs
+++ b/ddk-manager/tests/manager_execution_tests.rs
@@ -1712,7 +1712,8 @@ async fn cooperative_close_path(ctx: &mut TestContext, contract_id: ContractId) 
         .electrs
         .get_transaction_confirmations(&funding_txid)
         .await
-        .unwrap();
+        .unwrap()
+        .confirmations();
     assert!(
         confirmations > 0,
         "Funding transaction should be confirmed on blockchain"

--- a/ddk/src/chain/esplora.rs
+++ b/ddk/src/chain/esplora.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use crate::error::{esplora_err_to_manager_err, Error};
 use crate::logger::Logger;
-use crate::logger::{log_error, log_info, log_warn, WriteLog};
+use crate::logger::{log_debug, log_error, log_info, log_warn, WriteLog};
 use bdk_esplora::esplora_client::Error as EsploraError;
 use bdk_esplora::esplora_client::{AsyncClient, Builder};
 use bitcoin::Network;
 use bitcoin::{consensus::encode, Transaction, Txid};
 use ddk_manager::error::Error as ManagerError;
+use ddk_manager::ConfirmationStatus;
 use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
 
 /// Default request timeout (in seconds) for the Esplora client.
@@ -167,27 +168,46 @@ impl ddk_manager::Blockchain for EsploraClient {
     async fn get_transaction_confirmations(
         &self,
         tx_id: &bitcoin::Txid,
-    ) -> Result<u32, ManagerError> {
+    ) -> Result<ConfirmationStatus, ManagerError> {
         let txn = self
             .async_client
             .get_tx_status(tx_id)
             .await
             .map_err(esplora_err_to_manager_err)?;
-        let tip_height = self
-            .async_client
-            .get_height()
-            .await
-            .map_err(esplora_err_to_manager_err)?;
         if txn.confirmed {
-            match txn.block_height {
-                Some(height) => Ok(tip_height
+            let tip_height = self
+                .async_client
+                .get_height()
+                .await
+                .map_err(esplora_err_to_manager_err)?;
+            let confirmations = match txn.block_height {
+                Some(height) => tip_height
                     .checked_sub(height)
                     .map(|diff| diff + 1)
-                    .unwrap_or(0)),
-                None => Ok(0),
-            }
+                    .unwrap_or(0),
+                None => 0,
+            };
+            Ok(ConfirmationStatus::Confirmed(confirmations))
         } else {
-            Ok(0)
+            // Esplora reports `confirmed: false` both for transactions in the
+            // mempool and for transactions it does not know. Query the
+            // transaction itself to tell the two apart.
+            match self
+                .async_client
+                .get_tx(tx_id)
+                .await
+                .map_err(esplora_err_to_manager_err)?
+            {
+                Some(_) => Ok(ConfirmationStatus::InMempool),
+                None => {
+                    log_debug!(
+                        self.logger,
+                        "Transaction not found in mempool or on-chain. txid={}",
+                        tx_id.to_string()
+                    );
+                    Ok(ConfirmationStatus::NotFound)
+                }
+            }
         }
     }
 }

--- a/ddk/tests/chain.rs
+++ b/ddk/tests/chain.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use bitcoin::hashes::Hash;
+use bitcoin::{Amount, Network, Txid};
+use bitcoincore_rpc::RpcApi;
+use ddk::chain::EsploraClient;
+use ddk::logger::Logger;
+use ddk_manager::{Blockchain, ConfirmationStatus};
+
+/// The esplora client must tell apart a transaction the network does not
+/// know, a transaction in the mempool, and a confirmed transaction.
+///
+/// Before this split, a transaction that was evicted from the mempool and a
+/// transaction with zero confirmations both reported zero confirmations.
+/// With `NB_CONFIRMATIONS=0` the manager then moved contracts forward on
+/// transactions that did not exist.
+#[tokio::test]
+async fn esplora_reports_confirmation_status() {
+    let env = ddk_testenv::env();
+    let logger = Arc::new(Logger::disabled("chain-test".to_string()));
+    let esplora = EsploraClient::new(env.esplora_host(), Network::Regtest, logger).unwrap();
+
+    // A transaction the network does not know is reported as not found.
+    let unknown_txid = Txid::from_byte_array([7u8; 32]);
+    let status = esplora
+        .get_transaction_confirmations(&unknown_txid)
+        .await
+        .unwrap();
+    assert_eq!(status, ConfirmationStatus::NotFound);
+
+    // A transaction in the mempool is reported as in the mempool.
+    let address = env
+        .rpc()
+        .get_new_address(None, None)
+        .unwrap()
+        .assume_checked();
+    let txid = env.send_to_address(&address, Amount::from_btc(0.1).unwrap());
+    env.wait_for_tx(&txid);
+    let status = esplora.get_transaction_confirmations(&txid).await.unwrap();
+    assert_eq!(status, ConfirmationStatus::InMempool);
+    assert_eq!(status.confirmations(), 0);
+
+    // A mined transaction is reported as confirmed.
+    env.generate_blocks(1);
+    let status = esplora.get_transaction_confirmations(&txid).await.unwrap();
+    assert!(
+        matches!(status, ConfirmationStatus::Confirmed(n) if n >= 1),
+        "expected a confirmed status, got {:?}",
+        status
+    );
+    assert!(status.confirmations() >= 1);
+}

--- a/ddk/tests/stateless_utils.rs
+++ b/ddk/tests/stateless_utils.rs
@@ -255,7 +255,7 @@ impl ChainContext {
                 .esplora
                 .get_transaction_confirmations(&txid)
                 .await
-                .unwrap_or(0);
+                .map_or(0, |status| status.confirmations());
             if confirmations >= nb_blocks {
                 return;
             }
@@ -271,7 +271,7 @@ impl ChainContext {
                 .esplora
                 .get_transaction_confirmations(txid)
                 .await
-                .unwrap_or(0)
+                .map_or(0, |status| status.confirmations())
                 > 0
             {
                 return;


### PR DESCRIPTION
## Summary
Redo of #169. `Blockchain::get_transaction_confirmations` returned `Ok(0)` both for a transaction in the mempool and for a transaction the network does not know. With `NB_CONFIRMATIONS=0` the manager moved contracts through states on transactions that were evicted from the mempool or never broadcast. The trait now returns a `ConfirmationStatus` enum — `NotFound` / `InMempool` / `Confirmed(n)` — and the manager handles each case. There is no recovery scan over closed contracts: the state machine no longer enters `Closed` on a transaction that is not on-chain, so there is nothing to recover.

## Changes
- `ddk-manager/src/lib.rs`: new `ConfirmationStatus` enum with a `confirmations()` helper. `Blockchain::get_transaction_confirmations` returns it instead of a bare `u32`. This is a breaking change for trait implementers.
- `ddk/src/chain/esplora.rs`: when the status endpoint reports a transaction unconfirmed, query the transaction itself to tell "in the mempool" apart from "not found" (esplora reports both as unconfirmed). Transport errors stay `Err`, so a flaky esplora is not mistaken for a dropped transaction. The tip-height call now only runs for confirmed transactions.
- `check_signed_contract`: a missing funding transaction does not confirm the contract.
- `check_for_spliced_contract`: a missing splice funding transaction does not pre-close the previous contract.
- Pending close transactions that are missing are skipped instead of counted as zero confirmations.
- `check_preclosed_contract`: a missing closing transaction is broadcast again (safe when the chain source lags — the network accepts a transaction it already knows). If it cannot enter the mempool and the pre-close has no attestations (splice or cooperative close), the funding output is unspent and the contract moves back to `Confirmed`.
- Entering the terminal `Closed` state now requires at least one confirmation on-chain, also when `NB_CONFIRMATIONS=0`. No periodic check examines `Closed` contracts again, so a mempool-only transaction that later gets evicted must not put a contract there. This closes the exact incident path: with `NB_CONFIRMATIONS=0` a splice contract now stays `PreClosed` until its funding transaction is mined, and reverts to `Confirmed` if that transaction is dropped.
- New integration test `ddk/tests/chain.rs` asserts the esplora client reports `NotFound`, `InMempool`, and `Confirmed` correctly against a regtest backend.

## Testing
- `cargo test -p ddk -p ddk-manager` (full non-ignored suites) pass.
- `NB_CONFIRMATIONS=6 cargo test -p ddk-manager --test manager_execution_tests -- --ignored --exact splice_in_enum_single_oracle_test cooperative_close_single_oracle_test enum_single_oracle_refund_test` pass.
- Note: `cooperative_close_single_oracle_test` fails on master too when `NB_CONFIRMATIONS` is unset locally (CI sets it to 6); not related to this change.
- `cargo clippy` clean for the changed code; `cargo check --workspace` passes.
