### PR TITLE
chore: release 2.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "ddk"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-dlc"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-manager"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-messages"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-node"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-payouts"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-testenv"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "ddk-trie"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "bitcoin",
  "ddk-dlc",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "kormir"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ homepage = "https://github.com/bennyhodl/dlcdevkit"
 [workspace.dependencies]
 # Default-features are disabled here so no-std crates (dlc, dlc-messages, dlc-trie)
 # don't pull std. Std-using crates must opt in via `features = ["std"]`.
-ddk = { version = "2.0.0-rc.1", path = "ddk", default-features = false }
-ddk-dlc = { version = "2.0.0-rc.1", path = "dlc", default-features = false }
-ddk-messages = { version = "2.0.0-rc.1", path = "dlc-messages", default-features = false }
-ddk-trie = { version = "2.0.0-rc.1", path = "dlc-trie", default-features = false }
-ddk-manager = { version = "2.0.0-rc.1", path = "ddk-manager", default-features = false }
-ddk-payouts = { version = "2.0.0-rc.1", path = "payouts" }
-kormir = { version = "2.0.0-rc.1", path = "kormir" }
+ddk = { version = "2.0.0-rc.2", path = "ddk", default-features = false }
+ddk-dlc = { version = "2.0.0-rc.2", path = "dlc", default-features = false }
+ddk-messages = { version = "2.0.0-rc.2", path = "dlc-messages", default-features = false }
+ddk-trie = { version = "2.0.0-rc.2", path = "dlc-trie", default-features = false }
+ddk-manager = { version = "2.0.0-rc.2", path = "ddk-manager", default-features = false }
+ddk-payouts = { version = "2.0.0-rc.2", path = "payouts" }
+kormir = { version = "2.0.0-rc.2", path = "kormir" }
 # Path-only (no version): cargo strips it from the published manifests.
 ddk-testenv = { path = "testenv" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["ddk", "dlc", "dlc-messages", "dlc-trie", "payouts", "ddk-node", "ddk-manager", "kormir", "testenv"]
 
 [workspace.package]
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/bennyhodl/dlcdevkit"


### PR DESCRIPTION
Release version 2.0.0-rc.2

## Changes
- Bumped all crate versions to 2.0.0-rc.2
- Published crates to crates.io

## Release Notes
See releases/2.0.0-rc.2-RELEASE.md
