### PR TITLE
manager: track the offer chain hash on OfferedContract

### DIFF
--- a/ddk-manager/src/channel/offered_channel.rs
+++ b/ddk-manager/src/channel/offered_channel.rs
@@ -48,7 +48,7 @@ impl OfferedChannel {
         OfferChannel {
             protocol_version: crate::conversion_utils::PROTOCOL_VERSION,
             contract_flags: offered_contract.contract_flags,
-            chain_hash: crate::conversion_utils::BITCOIN_CHAINHASH,
+            chain_hash: offered_contract.offer_chain_hash(),
             temporary_contract_id: offered_contract.id,
             temporary_channel_id: self.temporary_channel_id,
             contract_info: offered_contract.into(),
@@ -123,6 +123,7 @@ impl OfferedChannel {
             funding_inputs: offer_channel.funding_inputs.clone(),
             total_collateral: offer_channel.contract_info.get_total_collateral(),
             contract_flags: offer_channel.contract_flags,
+            chain_hash: Some(offer_channel.chain_hash),
             keys_id,
         };
 

--- a/ddk-manager/src/channel_updater.rs
+++ b/ddk-manager/src/channel_updater.rs
@@ -119,6 +119,7 @@ where
         refund_delay,
         time.unix_time_now() as u32,
         keys_id,
+        crate::contract::chain_hash_from_network(blockchain.get_network()?),
     );
 
     let per_update_seed = signer_provider.get_new_secret_key()?;
@@ -1110,6 +1111,7 @@ pub fn renew_offer<C: Signing, SP: Deref, T: Deref, X: ContractSigner>(
     cet_nsequence: u32,
     signer_provider: &SP,
     time: &T,
+    chain_hash: [u8; 32],
 ) -> Result<(RenewOffer, OfferedContract), Error>
 where
     SP::Target: ContractSignerProvider<Signer = X>,
@@ -1168,6 +1170,7 @@ where
         refund_delay,
         time.unix_time_now() as u32,
         keys_id,
+        chain_hash,
     );
 
     offered_contract.fund_output_serial_id = 0;
@@ -1219,6 +1222,7 @@ pub fn on_renew_offer<T: Deref>(
     renew_offer: &RenewOffer,
     peer_timeout: u64,
     time: &T,
+    chain_hash: [u8; 32],
 ) -> Result<OfferedContract, Error>
 where
     T::Target: Time,
@@ -1249,6 +1253,7 @@ where
         cet_locktime: renew_offer.cet_locktime,
         refund_locktime: renew_offer.refund_locktime,
         contract_flags: 0,
+        chain_hash: Some(chain_hash),
         keys_id,
     };
 

--- a/ddk-manager/src/contract/mod.rs
+++ b/ddk-manager/src/contract/mod.rs
@@ -27,6 +27,12 @@ pub mod ser;
 pub mod signed_contract;
 pub(crate) mod utils;
 
+/// The genesis block hash identifying `network`, in the byte order DLC
+/// messages use for their `chain_hash` field.
+pub fn chain_hash_from_network(network: bitcoin::Network) -> [u8; 32] {
+    bitcoin::blockdata::constants::ChainHash::using_genesis_block_const(network).to_bytes()
+}
+
 /// Converts wire-level contract information into the execution information
 /// required to construct CETs and adaptor signatures.
 pub fn execution_contract_infos(

--- a/ddk-manager/src/contract/offered_contract.rs
+++ b/ddk-manager/src/contract/offered_contract.rs
@@ -1,7 +1,7 @@
 //! #OfferedContract
 
 use crate::conversion_utils::{
-    get_contract_info_and_announcements, get_tx_input_infos, BITCOIN_CHAINHASH, PROTOCOL_VERSION,
+    get_contract_info_and_announcements, get_tx_input_infos, LEGACY_CHAINHASH, PROTOCOL_VERSION,
 };
 use crate::dlc_input::get_dlc_inputs_from_funding_inputs;
 use crate::utils::get_new_serial_id;
@@ -50,6 +50,14 @@ pub struct OfferedContract {
     /// Feature flags for the contract (bit 0: refund to accepter).
     #[cfg_attr(feature = "use-serde", serde(default))]
     pub contract_flags: u8,
+    /// The genesis block hash of the chain the contract settles on, in DLC
+    /// message byte order, as it appeared on the offer message.
+    ///
+    /// [`None`] for contracts stored before ddk tracked this. Rebuilding an
+    /// offer message from those contracts uses the same genesis hash the old
+    /// conversion always wrote (regtest), so the message bytes stay the same.
+    #[cfg_attr(feature = "use-serde", serde(default))]
+    pub chain_hash: Option<[u8; 32]>,
     /// Keys Id for generating the signers
     pub(crate) keys_id: KeysId,
 }
@@ -93,6 +101,7 @@ impl OfferedContract {
         refund_delay: u32,
         cet_locktime: u32,
         keys_id: KeysId,
+        chain_hash: [u8; 32],
     ) -> Self {
         let total_collateral = contract.offer_collateral + contract.accept_collateral;
 
@@ -124,6 +133,7 @@ impl OfferedContract {
             cet_locktime,
             refund_locktime: latest_maturity + refund_delay,
             contract_flags: contract.contract_flags,
+            chain_hash: Some(chain_hash),
             counter_party: *counter_party,
             keys_id,
         }
@@ -162,9 +172,19 @@ impl OfferedContract {
             funding_inputs: offer_dlc.funding_inputs.clone(),
             total_collateral: offer_dlc.contract_info.get_total_collateral(),
             contract_flags: offer_dlc.contract_flags,
+            chain_hash: Some(offer_dlc.chain_hash),
             counter_party,
             keys_id,
         })
+    }
+
+    /// The chain hash to put on offer messages for this contract.
+    ///
+    /// Contracts stored before ddk tracked the chain hash have none to
+    /// report, so this returns the genesis hash the old conversion always
+    /// wrote.
+    pub(crate) fn offer_chain_hash(&self) -> [u8; 32] {
+        self.chain_hash.unwrap_or(LEGACY_CHAINHASH)
     }
 }
 
@@ -174,7 +194,7 @@ impl From<&OfferedContract> for OfferDlc {
             protocol_version: PROTOCOL_VERSION,
             temporary_contract_id: offered_contract.id,
             contract_flags: offered_contract.contract_flags,
-            chain_hash: BITCOIN_CHAINHASH,
+            chain_hash: offered_contract.offer_chain_hash(),
             contract_info: offered_contract.into(),
             funding_pubkey: offered_contract.offer_params.fund_pubkey,
             payout_spk: offered_contract.offer_params.payout_script_pubkey.clone(),
@@ -194,10 +214,50 @@ impl From<&OfferedContract> for OfferDlc {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contract::chain_hash_from_network;
+    use bitcoin::Network;
 
     fn validate_offer_test_common(input: &str) {
         let offer: OfferedContract = serde_json::from_str(input).unwrap();
         assert!(offer.validate().is_err());
+    }
+
+    fn offered_contract(chain_hash: Option<[u8; 32]>) -> OfferedContract {
+        let offer_dlc: OfferDlc =
+            serde_json::from_str(include_str!("../../test_inputs/offer_contract.json")).unwrap();
+        let counter_party: PublicKey =
+            "02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443"
+                .parse()
+                .unwrap();
+        let mut offered =
+            OfferedContract::try_from_offer_dlc(&offer_dlc, counter_party, [7u8; 32]).unwrap();
+        offered.chain_hash = chain_hash;
+        offered
+    }
+
+    /// The chain hash of a received offer is the one we send back out.
+    #[test]
+    fn stored_chain_hash_survives_the_offer_round_trip() {
+        let mainnet = chain_hash_from_network(Network::Bitcoin);
+        let offered = offered_contract(Some(mainnet));
+        let offer: OfferDlc = (&offered).into();
+
+        assert_eq!(offer.chain_hash, mainnet);
+    }
+
+    /// A contract stored before ddk tracked the chain hash rebuilds the offer
+    /// with the same genesis hash the old conversion always wrote.
+    #[test]
+    fn contract_without_chain_hash_falls_back_to_the_legacy_constant() {
+        let offered = offered_contract(None);
+        let offer: OfferDlc = (&offered).into();
+
+        assert_eq!(offer.chain_hash, LEGACY_CHAINHASH);
+    }
+
+    #[test]
+    fn legacy_chain_hash_is_regtest_genesis() {
+        assert_eq!(LEGACY_CHAINHASH, chain_hash_from_network(Network::Regtest));
     }
 
     #[test]

--- a/ddk-manager/src/contract/ser.rs
+++ b/ddk-manager/src/contract/ser.rs
@@ -102,6 +102,11 @@ impl Writeable for OfferedContract {
         self.cet_locktime.write(w)?;
         self.refund_locktime.write(w)?;
         self.contract_flags.write(w)?;
+        // Written only when present, so contracts stored before ddk tracked
+        // the chain hash keep re-serializing to their original bytes.
+        if let Some(chain_hash) = self.chain_hash {
+            chain_hash.write(w)?;
+        }
         self.counter_party.write(w)?;
         self.keys_id.write(w)?;
         Ok(())
@@ -121,24 +126,44 @@ impl Readable for OfferedContract {
         let cet_locktime: u32 = Readable::read(r)?;
         let refund_locktime: u32 = Readable::read(r)?;
 
-        // Backward compatibility: contract_flags (u8) was inserted between
-        // refund_locktime and counter_party. Peek one byte: 0x02/0x03 means
-        // old format (compressed pubkey prefix), 0x00/0x01 means new format
-        // (contract_flags value).
+        // Backward compatibility: contract_flags (u8) and later chain_hash
+        // ([u8; 32]) were inserted between refund_locktime and counter_party,
+        // and either may be absent in a stored contract. A compressed pubkey
+        // starts with 0x02/0x03, while contract_flags is 0x00/0x01 and no
+        // supported network's chain hash starts with those bytes (see the
+        // chain_hash_first_byte_is_not_a_pubkey_prefix test), so peeking one
+        // byte tells the formats apart at each step.
         let mut peek = [0u8; 1];
         r.read_exact(&mut peek)?;
-        let (contract_flags, counter_party) = if peek[0] == 0x02 || peek[0] == 0x03 {
-            // Old format: this byte is the start of counter_party pubkey
-            let mut pubkey_bytes = [0u8; 33];
-            pubkey_bytes[0] = peek[0];
-            r.read_exact(&mut pubkey_bytes[1..])?;
-            let pk = secp256k1_zkp::PublicKey::from_slice(&pubkey_bytes)
-                .map_err(|_| DecodeError::InvalidValue)?;
-            (0u8, pk)
+        let read_pubkey_from_first_byte =
+            |first: u8, r: &mut R| -> Result<secp256k1_zkp::PublicKey, DecodeError> {
+                let mut pubkey_bytes = [0u8; 33];
+                pubkey_bytes[0] = first;
+                r.read_exact(&mut pubkey_bytes[1..])?;
+                secp256k1_zkp::PublicKey::from_slice(&pubkey_bytes)
+                    .map_err(|_| DecodeError::InvalidValue)
+            };
+        let (contract_flags, chain_hash, counter_party) = if peek[0] == 0x02 || peek[0] == 0x03 {
+            // Stored without contract_flags or chain_hash: this byte starts
+            // the counter_party pubkey.
+            let pk = read_pubkey_from_first_byte(peek[0], r)?;
+            (0u8, None, pk)
         } else {
-            // New format: this byte is contract_flags
-            let counter_party: secp256k1_zkp::PublicKey = Readable::read(r)?;
-            (peek[0], counter_party)
+            // This byte is contract_flags; peek again to tell whether
+            // chain_hash follows or counter_party starts directly.
+            let contract_flags = peek[0];
+            r.read_exact(&mut peek)?;
+            if peek[0] == 0x02 || peek[0] == 0x03 {
+                // Stored with contract_flags but without chain_hash.
+                let pk = read_pubkey_from_first_byte(peek[0], r)?;
+                (contract_flags, None, pk)
+            } else {
+                let mut chain_hash = [0u8; 32];
+                chain_hash[0] = peek[0];
+                r.read_exact(&mut chain_hash[1..])?;
+                let counter_party: secp256k1_zkp::PublicKey = Readable::read(r)?;
+                (contract_flags, Some(chain_hash), counter_party)
+            }
         };
 
         let keys_id: KeysId = Readable::read(r)?;
@@ -155,6 +180,7 @@ impl Readable for OfferedContract {
             cet_locktime,
             refund_locktime,
             contract_flags,
+            chain_hash,
             counter_party,
             keys_id,
         })
@@ -335,4 +361,118 @@ fn read_multi_oracle_trie_with_diff<R: Read>(
 ) -> Result<MultiOracleTrieWithDiff, DecodeError> {
     let dump = multi_oracle_trie_with_diff_dump::read(reader)?;
     Ok(MultiOracleTrieWithDiff::from_dump(dump))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::chain_hash_from_network;
+    use bitcoin::Network;
+    use lightning::io::Cursor;
+
+    fn offered_contract() -> OfferedContract {
+        let offer_dlc: ddk_messages::OfferDlc =
+            serde_json::from_str(include_str!("../../test_inputs/offer_contract.json")).unwrap();
+        let counter_party = "02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443"
+            .parse()
+            .unwrap();
+        OfferedContract::try_from_offer_dlc(&offer_dlc, counter_party, [7u8; 32]).unwrap()
+    }
+
+    /// Serializes `contract` in the formats used before chain_hash (and,
+    /// with `with_contract_flags` false, before contract_flags) existed.
+    fn serialize_pre_chain_hash(contract: &OfferedContract, with_contract_flags: bool) -> Vec<u8> {
+        let mut w = Vec::new();
+        contract.id.write(&mut w).unwrap();
+        contract.is_offer_party.write(&mut w).unwrap();
+        write_vec(&contract.contract_info, &mut w).unwrap();
+        ddk_messages::ser_impls::party_params::write(&contract.offer_params, &mut w).unwrap();
+        contract.total_collateral.write(&mut w).unwrap();
+        write_vec(&contract.funding_inputs, &mut w).unwrap();
+        contract.fund_output_serial_id.write(&mut w).unwrap();
+        contract.fee_rate_per_vb.write(&mut w).unwrap();
+        contract.cet_locktime.write(&mut w).unwrap();
+        contract.refund_locktime.write(&mut w).unwrap();
+        if with_contract_flags {
+            contract.contract_flags.write(&mut w).unwrap();
+        }
+        contract.counter_party.write(&mut w).unwrap();
+        contract.keys_id.write(&mut w).unwrap();
+        w
+    }
+
+    #[test]
+    fn chain_hash_survives_storage_round_trip() {
+        let mut contract = offered_contract();
+        contract.chain_hash = Some(chain_hash_from_network(Network::Bitcoin));
+        contract.contract_flags = 1;
+
+        let serialized = contract.serialize().unwrap();
+        let read = OfferedContract::deserialize(&mut Cursor::new(&serialized)).unwrap();
+
+        assert_eq!(read.chain_hash, contract.chain_hash);
+        assert_eq!(read.contract_flags, contract.contract_flags);
+        assert_eq!(read.counter_party, contract.counter_party);
+        assert_eq!(read.keys_id, contract.keys_id);
+    }
+
+    #[test]
+    fn contract_stored_without_chain_hash_reads_as_none() {
+        let mut contract = offered_contract();
+        contract.contract_flags = 1;
+        let serialized = serialize_pre_chain_hash(&contract, true);
+
+        let read = OfferedContract::deserialize(&mut Cursor::new(&serialized)).unwrap();
+
+        assert_eq!(read.chain_hash, None);
+        assert_eq!(read.contract_flags, contract.contract_flags);
+        assert_eq!(read.counter_party, contract.counter_party);
+        assert_eq!(read.keys_id, contract.keys_id);
+    }
+
+    #[test]
+    fn contract_stored_without_contract_flags_reads_as_none() {
+        let contract = offered_contract();
+        let serialized = serialize_pre_chain_hash(&contract, false);
+
+        let read = OfferedContract::deserialize(&mut Cursor::new(&serialized)).unwrap();
+
+        assert_eq!(read.chain_hash, None);
+        assert_eq!(read.contract_flags, 0);
+        assert_eq!(read.counter_party, contract.counter_party);
+        assert_eq!(read.keys_id, contract.keys_id);
+    }
+
+    /// A contract with no chain hash writes the bytes it was stored as, so
+    /// upgrading ddk does not rewrite contracts already in a database.
+    #[test]
+    fn contract_without_chain_hash_reserializes_unchanged() {
+        let mut contract = offered_contract();
+        contract.contract_flags = 1;
+        let stored = serialize_pre_chain_hash(&contract, true);
+
+        let read = OfferedContract::deserialize(&mut Cursor::new(&stored)).unwrap();
+
+        assert_eq!(read.serialize().unwrap(), stored);
+    }
+
+    /// The backward-compatible read of [`OfferedContract`] tells a chain hash
+    /// apart from a compressed pubkey by its first byte, so no supported
+    /// network's chain hash may start with a pubkey prefix (0x02/0x03).
+    #[test]
+    fn chain_hash_first_byte_is_not_a_pubkey_prefix() {
+        for network in [
+            Network::Bitcoin,
+            Network::Testnet,
+            Network::Testnet4,
+            Network::Signet,
+            Network::Regtest,
+        ] {
+            let first = chain_hash_from_network(network)[0];
+            assert!(
+                first != 0x02 && first != 0x03,
+                "{network} chain hash starts with a pubkey prefix byte"
+            );
+        }
+    }
 }

--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -94,6 +94,8 @@ where
         party_params.collateral.to_sat(),
     );
 
+    let chain_hash = crate::contract::chain_hash_from_network(blockchain.get_network()?);
+
     let offered_contract = OfferedContract::new(
         id,
         contract_input,
@@ -104,9 +106,10 @@ where
         refund_delay,
         time.unix_time_now() as u32,
         keys_id,
+        chain_hash,
     );
 
-    let offer_msg: OfferDlc = (&offered_contract).into();
+    let offer_msg = OfferDlc::from(&offered_contract);
 
     Ok((offered_contract, offer_msg))
 }

--- a/ddk-manager/src/conversion_utils.rs
+++ b/ddk-manager/src/conversion_utils.rs
@@ -31,12 +31,17 @@ use ddk_messages::{
 use ddk_trie::OracleNumericInfo;
 use std::fmt;
 
-pub(crate) const BITCOIN_CHAINHASH: [u8; 32] = [
+pub(crate) const PROTOCOL_VERSION: u32 = 1;
+
+/// Genesis hash that pre-upgrade code wrote on every `OfferDlc`.
+///
+/// Despite the old `BITCOIN_CHAINHASH` name, this is the regtest genesis
+/// hash. Used only when a stored [`OfferedContract`] has no chain hash, so
+/// rebuilding the offer message matches the bytes that originally went out.
+pub(crate) const LEGACY_CHAINHASH: [u8; 32] = [
     0x06, 0x22, 0x6e, 0x46, 0x11, 0x1a, 0x0b, 0x59, 0xca, 0xaf, 0x12, 0x60, 0x43, 0xeb, 0x5b, 0xbf,
     0x28, 0xc3, 0x4f, 0x3a, 0x5e, 0x33, 0x2a, 0x1f, 0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88, 0x91, 0x0f,
 ];
-
-pub(crate) const PROTOCOL_VERSION: u32 = 1;
 
 #[derive(Debug)]
 pub enum Error {

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -2019,6 +2019,7 @@ where
             CET_NSEQUENCE,
             &self.signer_provider,
             &self.time,
+            crate::contract::chain_hash_from_network(self.blockchain.get_network()?),
         )?;
 
         let counter_party = offered_contract.counter_party;
@@ -2670,6 +2671,7 @@ where
             renew_offer,
             PEER_TIMEOUT,
             &self.time,
+            crate::contract::chain_hash_from_network(self.blockchain.get_network()?),
         )?;
 
         self.store.create_contract(&offered_contract).await?;

--- a/ddk/src/contract/types.rs
+++ b/ddk/src/contract/types.rs
@@ -1,6 +1,5 @@
 //! Parameter and result types for the stateless contract API.
 
-use bitcoin::blockdata::constants::ChainHash;
 use bitcoin::key::rand::{thread_rng, Rng};
 use bitcoin::psbt::Psbt;
 use bitcoin::{Amount, Network, ScriptBuf, Transaction};
@@ -193,7 +192,7 @@ pub fn funding_input(
 /// Returns the DLC chain hash for a network, suitable for
 /// [`CreateOfferParams::chain_hash`].
 pub fn chain_hash_from_network(network: Network) -> [u8; 32] {
-    ChainHash::using_genesis_block_const(network).to_bytes()
+    ddk_manager::contract::chain_hash_from_network(network)
 }
 
 pub(crate) fn network_from_chain_hash(chain_hash: [u8; 32]) -> Option<Network> {

--- a/ddk/src/util/ser.rs
+++ b/ddk/src/util/ser.rs
@@ -271,6 +271,36 @@ mod tests {
         deserialize_contract(&stored.to_vec()).expect("oldest offered contract to deserialize");
     }
 
+    /// The fixtures predate ddk tracking the chain hash, so they carry none.
+    ///
+    /// This is what makes `stored_contracts_round_trip_byte_for_byte` above
+    /// meaningful for the chain hash: a contract with no stored chain hash
+    /// writes exactly the bytes it was read from, so upgrading ddk leaves
+    /// contracts already in a database untouched.
+    #[test]
+    fn stored_contracts_predating_the_chain_hash_carry_none() {
+        for (state, stored) in FIXTURES {
+            let contract = deserialize_contract(&stored.to_vec())
+                .unwrap_or_else(|e| panic!("{state} contract failed to deserialize: {e:?}"));
+
+            let offered = match &contract {
+                Contract::Offered(o) | Contract::Rejected(o) => o,
+                Contract::Accepted(a) => &a.offered_contract,
+                Contract::Signed(s) | Contract::Confirmed(s) | Contract::Refunded(s) => {
+                    &s.accepted_contract.offered_contract
+                }
+                Contract::PreClosed(p) => &p.signed_contract.accepted_contract.offered_contract,
+                Contract::Closed(c) => &c.signed_contract.accepted_contract.offered_contract,
+                Contract::FailedAccept(f) => &f.offered_contract,
+                Contract::FailedSign(f) => &f.accepted_contract.offered_contract,
+            };
+            assert_eq!(
+                offered.chain_hash, None,
+                "{state} fixture unexpectedly carries a chain hash"
+            );
+        }
+    }
+
     /// The announcement inside a stored contract is the one the oracle signed.
     ///
     /// Reading it out and writing it back as a standalone TLV record must reproduce


### PR DESCRIPTION
## Summary
Offer messages always went out with a hardcoded chain hash — a constant named `BITCOIN_CHAINHASH` that in fact held the regtest genesis hash. `OfferedContract` now stores the chain hash, so each offer message identifies the chain the contract settles on.

## Changes
- Add an optional `chain_hash` field to `OfferedContract`. New contracts fill it from the blockchain's network; contracts built from a received offer keep the hash from the wire message.
- Rebuild offer messages (`OfferDlc`, `OfferChannel`, renew offers) from the stored hash instead of the hardcoded constant.
- Rename `BITCOIN_CHAINHASH` to `LEGACY_CHAINHASH`. It is now only the fallback for contracts stored before the field existed, so their rebuilt offer messages keep the original bytes.
- Extend the backward-compatible `OfferedContract` (de)serialization: the one-byte peek that told `contract_flags` apart from the pubkey now also tells whether a chain hash follows. Contracts stored without one read back as `None` and re-serialize byte-for-byte unchanged.
- Add `ddk_manager::contract::chain_hash_from_network` and point the ddk stateless-API helper at it.

## Testing
- `cargo test -p ddk-manager` — the new tests pass: offer round trip, legacy fallback, storage round trip, old-format reads, and the check that no supported network's chain hash starts with a pubkey prefix byte.
- `cargo test -p ddk stored_contracts` — the stored fixtures still deserialize, carry no chain hash, and round-trip byte-for-byte.
