### PR TITLE
ddk: harden contract-key derivation (V1) and keep V0 for unlocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "zeroize",
  "zeromq",
 ]
 

--- a/ddk-manager/src/channel_updater.rs
+++ b/ddk-manager/src/channel_updater.rs
@@ -93,7 +93,7 @@ where
     T::Target: Time,
 {
     let id = get_new_temporary_id();
-    let keys_id = signer_provider.derive_signer_key_id(true, id);
+    let keys_id = signer_provider.derive_signer_key_id(id);
     let signer = signer_provider.derive_contract_signer(keys_id)?;
     let total_collateral = contract.offer_collateral + contract.accept_collateral;
     let (offer_params, funding_inputs_info) = crate::utils::get_party_params(

--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -66,7 +66,7 @@ where
     contract_input.validate()?;
 
     let id = crate::utils::get_new_temporary_id();
-    let keys_id = signer_provider.derive_signer_key_id(true, id);
+    let keys_id = signer_provider.derive_signer_key_id(id);
     let signer = signer_provider.derive_contract_signer(keys_id)?;
     let total_collateral = contract_input.offer_collateral + contract_input.accept_collateral;
     let (party_params, funding_inputs_info) = crate::utils::get_party_params(

--- a/ddk-manager/src/lib.rs
+++ b/ddk-manager/src/lib.rs
@@ -11,6 +11,9 @@
 #![deny(dead_code)]
 #![deny(unused_imports)]
 #![deny(missing_docs)]
+// Deprecated items in the key-provider API are unlock-only compatibility paths.
+// Naming one is a hard error in this crate.
+#![deny(deprecated)]
 // Without the `manager` feature the async application layer (`manager` /
 // `channel_updater`) is compiled out, leaving some protocol helpers with no
 // callers in this subset build. The default build compiles the superset and
@@ -135,8 +138,12 @@ pub trait ContractSignerProvider {
     /// A type which implements [`ContractSigner`]
     type Signer: ContractSigner;
 
-    /// Create a keys id for deriving a `Signer`.
-    fn derive_signer_key_id(&self, is_offer_party: bool, temp_id: [u8; 32]) -> [u8; 32];
+    /// Create a keys id for deriving a `Signer` from a contract's temporary id.
+    ///
+    /// Both sides of a contract call this with the same `temp_id`. The id is a
+    /// pure function of `temp_id` and the provider's own key material, so the
+    /// two parties still derive unrelated keys.
+    fn derive_signer_key_id(&self, temp_id: [u8; 32]) -> [u8; 32];
 
     /// Derives the private key material backing a `Signer`.
     fn derive_contract_signer(&self, key_id: [u8; 32]) -> Result<Self::Signer, Error>;
@@ -334,9 +341,8 @@ where
 {
     type Signer = X;
 
-    fn derive_signer_key_id(&self, is_offer_party: bool, temp_id: [u8; 32]) -> KeysId {
-        self.signer_provider
-            .derive_signer_key_id(is_offer_party, temp_id)
+    fn derive_signer_key_id(&self, temp_id: [u8; 32]) -> KeysId {
+        self.signer_provider.derive_signer_key_id(temp_id)
     }
 
     fn derive_contract_signer(&self, key_id: KeysId) -> Result<Self::Signer, Error> {

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -552,7 +552,7 @@ where
         offered_message.validate(&self.secp, REFUND_DELAY, REFUND_DELAY * 2)?;
         let keys_id = self
             .signer_provider
-            .derive_signer_key_id(false, offered_message.temporary_contract_id);
+            .derive_signer_key_id(offered_message.temporary_contract_id);
         let contract: OfferedContract =
             OfferedContract::try_from_offer_dlc(offered_message, counter_party, keys_id)?;
         contract.validate()?;
@@ -2299,7 +2299,7 @@ where
 
         let keys_id = self
             .signer_provider
-            .derive_signer_key_id(false, offer_channel.temporary_contract_id);
+            .derive_signer_key_id(offer_channel.temporary_contract_id);
         let (channel, contract) =
             OfferedChannel::from_offer_channel(offer_channel, counter_party, keys_id)?;
 

--- a/ddk/Cargo.toml
+++ b/ddk/Cargo.toml
@@ -84,6 +84,7 @@ hmac = { version = "0.13.0", optional = true }
 sha2 = { version = "0.11.0", optional = true }
 nostr-database = { version = "0.44.0", optional = true }
 bip39 = "2.2.0"
+zeroize = "1"
 
 # zmq feature
 zeromq = { version = "0.6.0", optional = true }

--- a/ddk/examples/stateless_splice.rs
+++ b/ddk/examples/stateless_splice.rs
@@ -264,7 +264,8 @@ async fn main() {
 
     // Offer side: sign the new wallet UTXO, then produce this party's half of the
     // prior 2-of-2. The prior funding key is RE-DERIVED from `temp_id_a` — not
-    // stored — via the provider's `dlc_input_signing_key` helper.
+    // stored — via the provider's `dlc_input_signing_key` helper. The funding
+    // pubkey from the prior offer selects the key scheme the prior contract used.
     let mut offer_b_psbt = create_funding_psbt(&offer_b, &accept_b).unwrap();
     signing::sign_funding_psbt_with_wallet(
         &offer_b,
@@ -276,7 +277,7 @@ async fn main() {
     .await
     .expect("offer B wallet signing");
     let offer_prior_key = offerer_keys
-        .dlc_input_signing_key(temp_id_a, splice_serial)
+        .dlc_input_signing_key(temp_id_a, &offer_a.funding_pubkey, splice_serial)
         .expect("recover offer prior key");
     let sign_b = sign_accept_spliced(
         &offer_b,
@@ -291,7 +292,7 @@ async fn main() {
     // again from the RE-DERIVED prior funding key.
     let accept_b_psbt = create_funding_psbt(&offer_b, &accept_b).unwrap();
     let accept_prior_key = accepter_keys
-        .dlc_input_signing_key(temp_id_a, splice_serial)
+        .dlc_input_signing_key(temp_id_a, &accept_a.funding_pubkey, splice_serial)
         .expect("recover accept prior key");
     let funding_tx_b = finalize_sign_spliced(
         &offer_b,

--- a/ddk/src/contract/keys.rs
+++ b/ddk/src/contract/keys.rs
@@ -6,6 +6,38 @@
 //! temporary id. Nothing is stored: given a master extended private key and a
 //! contract's temporary id, the exact funding key is recomputed on demand.
 //!
+//! # Derivation schemes
+//!
+//! Two schemes exist. New contracts always use V1; V0 stays supported so that
+//! contracts funded by earlier releases keep working after an upgrade.
+//!
+//! ```text
+//! V1 (from 2.0.0-rc.3)
+//!   keys_id  = SHA256( fingerprint || temporary_contract_id || "CONTRACT_SIGNER_KEY_ID_V1" )[0..24]
+//!              || "DDKKEYv1"
+//!   l1,l2,l3 = keys_id[0..4], keys_id[4..8], keys_id[8..12], each mod 3400
+//!   base_sk  = BIP32 private child at  m/420'/0'/0'/l1'/l2'/l3'
+//!   sk       = SHA256( "CONTRACT_KEY_V1" || base_sk || l1 || l2 || l3 )
+//!
+//! V0 (all earlier releases)
+//!   keys_id  = SHA256( fingerprint || temporary_contract_id || "CONTRACT_SIGNER_KEY_ID_V0" )
+//!   l1,l2,l3 = as above
+//!   base_sk  = BIP32 private child at  m/420'/0'/0'/l1/l2/l3        (not hardened)
+//!   sk       = SHA256( fingerprint || base_sk || l1 || l2 || l3 )
+//! ```
+//!
+//! In V1 every level of the BIP32 path is hardened. A leaked contract key
+//! together with any ancestor extended public key does not give an attacker the
+//! parent private key, so the security of the scheme is the security of the
+//! master extended private key, exactly as in a plain BIP32 wallet. The final
+//! hash is defense in depth only: it is not load-bearing.
+//!
+//! A `keys_id` carries its scheme: V1 ids end with the 8-byte marker
+//! `DDKKEYv1`, and any other id is V0. The manager stores the `keys_id` with
+//! each contract, so [`ContractKeyProvider::funding_secret_key_for_keys_id`]
+//! (and the [`ddk_manager::ContractSignerProvider`] impl) derive the right key
+//! for old and new contracts alike. See [`KeyScheme`].
+//!
 //! This is the mechanism the stateless splice API needs. To spend a previous
 //! contract's funding output the caller must supply that contract's funding
 //! secret key ([`DlcInputSigningKey`]); [`ContractKeyProvider::dlc_input_signing_key`]
@@ -25,6 +57,7 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{All, PublicKey, Secp256k1, SecretKey};
 use bitcoin::Network;
 use ddk_manager::SimpleSigner;
+use zeroize::Zeroize;
 
 use super::error::ContractError;
 use super::types::DlcInputSigningKey;
@@ -37,10 +70,69 @@ const CHILD_NUMBER_RANGE: u32 = 3_400;
 /// Base derivation path for contract keys.
 const DLC_BASE_PATH: &str = "m/420'/0'/0'";
 
-/// Domain-separation tag for the keys-id hash. Must stay in lockstep with
-/// [`crate::wallet::DlcDevKitWallet`] or keys derived by one will not match the
-/// other.
-const KEYS_ID_TAG: &[u8] = b"CONTRACT_SIGNER_KEY_ID_V0";
+/// Domain-separation tag for the V0 keys-id hash.
+const KEYS_ID_TAG_V0: &[u8] = b"CONTRACT_SIGNER_KEY_ID_V0";
+
+/// Domain-separation tag for the V1 keys-id hash.
+const KEYS_ID_TAG_V1: &[u8] = b"CONTRACT_SIGNER_KEY_ID_V1";
+
+/// Trailing marker that identifies a V1 `keys_id`. Occupies bytes `24..32`,
+/// which the derivation never reads. A V0 id is a full SHA-256 output, so the
+/// chance that it ends with this marker by accident is 2^-64.
+const KEYS_ID_V1_MARKER: &[u8; 8] = b"DDKKEYv1";
+
+/// Domain-separation tag for the V1 hardening hash over the BIP32 child key.
+const HARDEN_TAG_V1: &[u8] = b"CONTRACT_KEY_V1";
+
+/// The derivation scheme behind a `keys_id` or funding key.
+///
+/// New contracts use [`KeyScheme::V1`]. [`KeyScheme::V0`] is the scheme of
+/// releases before `2.0.0-rc.3`. It exists only to *unlock* contracts funded by
+/// those releases: the library selects it automatically when a stored
+/// `keys_id` has no V1 marker ([`KeyScheme::of_keys_id`]) or when a published
+/// funding pubkey only matches under V0
+/// ([`ContractKeyProvider::funding_secret_key_for_pubkey`]). Naming
+/// `KeyScheme::V0` in code is a deprecation diagnostic, and a hard error inside
+/// the `ddk` and `ddk-manager` crates, so no new contract can be created on V0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyScheme {
+    /// Non-hardened contract levels, fingerprint-keyed final hash.
+    ///
+    /// Unlock-only. Do not derive new keys on this scheme; use
+    /// [`KeyScheme::CURRENT`], or one of the resolvers that pick the scheme
+    /// from stored data.
+    #[deprecated(
+        since = "2.0.0-rc.3",
+        note = "V0 only unlocks contracts funded before 2.0.0-rc.3. Do not name it: \
+                use `funding_secret_key_for_keys_id` or `funding_secret_key_for_pubkey`, \
+                which select the scheme from the stored keys_id or the published pubkey."
+    )]
+    V0,
+    /// Hardened contract levels, domain-tagged final hash.
+    V1,
+}
+
+impl KeyScheme {
+    /// The scheme new contracts use.
+    pub const CURRENT: KeyScheme = KeyScheme::V1;
+
+    /// Every scheme, newest first. Recovery code that has only a temporary id
+    /// and a funding public key tries these in order.
+    // The one sanctioned place that lists V0: resolvers walk this to unlock.
+    #[allow(deprecated)]
+    pub const ALL: [KeyScheme; 2] = [KeyScheme::V1, KeyScheme::V0];
+
+    /// Reads the scheme a `keys_id` was produced under.
+    // Unlock path: a stored id without the V1 marker was made by an old release.
+    #[allow(deprecated)]
+    pub fn of_keys_id(keys_id: &[u8; 32]) -> KeyScheme {
+        if &keys_id[24..32] == KEYS_ID_V1_MARKER {
+            KeyScheme::V1
+        } else {
+            KeyScheme::V0
+        }
+    }
+}
 
 /// Deterministically derives DLC contract funding keys from a master extended
 /// private key.
@@ -116,39 +208,118 @@ impl ContractKeyProvider {
         Ok(Self::from_xprv(xprv))
     }
 
-    /// The `keys_id` for a contract, a deterministic function of its temporary id.
+    /// The `keys_id` for a new contract, a deterministic function of its
+    /// temporary id under the current scheme ([`KeyScheme::CURRENT`]).
     pub fn keys_id(&self, temporary_contract_id: [u8; 32]) -> [u8; 32] {
-        let mut input = Vec::with_capacity(4 + 32 + KEYS_ID_TAG.len());
+        self.keys_id_with_scheme(temporary_contract_id, KeyScheme::CURRENT)
+    }
+
+    /// The `keys_id` for a contract under a specific scheme.
+    ///
+    /// Prefer [`keys_id`](Self::keys_id). Passing `KeyScheme::V0` is a
+    /// deprecation diagnostic; recovery tools that must rebuild an old id
+    /// should go through [`funding_secret_key_for_pubkey`](Self::funding_secret_key_for_pubkey).
+    // Dispatches on both schemes, so it must be able to name V0.
+    #[allow(deprecated)]
+    pub fn keys_id_with_scheme(
+        &self,
+        temporary_contract_id: [u8; 32],
+        scheme: KeyScheme,
+    ) -> [u8; 32] {
+        let tag = match scheme {
+            KeyScheme::V0 => KEYS_ID_TAG_V0,
+            KeyScheme::V1 => KEYS_ID_TAG_V1,
+        };
+        let mut input = Vec::with_capacity(4 + 32 + tag.len());
         input.extend_from_slice(self.fingerprint.as_bytes());
         input.extend_from_slice(&temporary_contract_id);
-        input.extend_from_slice(KEYS_ID_TAG);
-        sha256::Hash::hash(&input).to_byte_array()
+        input.extend_from_slice(tag);
+        let mut keys_id = sha256::Hash::hash(&input).to_byte_array();
+        if scheme == KeyScheme::V1 {
+            keys_id[24..32].copy_from_slice(KEYS_ID_V1_MARKER);
+        }
+        keys_id
     }
 
     /// The funding secret key for a `keys_id`.
+    ///
+    /// The scheme is read from the id itself ([`KeyScheme::of_keys_id`]), so a
+    /// `keys_id` stored by an earlier release derives the same key it always
+    /// did, and a new id derives a V1 key.
+    // Dispatches on both schemes, so it must be able to name V0.
+    #[allow(deprecated)]
     pub fn funding_secret_key_for_keys_id(
         &self,
         keys_id: [u8; 32],
     ) -> Result<SecretKey, ContractError> {
+        let scheme = KeyScheme::of_keys_id(&keys_id);
         let (level_1, level_2, level_3) = hierarchical_indices(keys_id);
-        let path = self.hierarchical_derivation_path(level_1, level_2, level_3)?;
-        let base_key = self
+        let path = self.hierarchical_derivation_path(scheme, level_1, level_2, level_3)?;
+        let mut child = self
             .xprv
             .derive_priv(&self.secp, &path)
-            .map_err(|e| ContractError::Bip32(e.to_string()))?
-            .private_key;
-        self.harden(&base_key, level_1, level_2, level_3)
+            .map_err(|e| ContractError::Bip32(e.to_string()))?;
+        let hardened = match scheme {
+            KeyScheme::V0 => harden_v0(
+                &self.fingerprint,
+                &child.private_key,
+                level_1,
+                level_2,
+                level_3,
+            ),
+            KeyScheme::V1 => harden_v1(&child.private_key, level_1, level_2, level_3),
+        };
+        // The BIP32 child is a real secret in the wallet's subtree. It is only an
+        // intermediate value here, so wipe it as soon as the final key exists.
+        child.private_key.non_secure_erase();
+        hardened
     }
 
-    /// The funding secret key for a contract, from its temporary id.
+    /// The funding secret key for a new contract, from its temporary id, under
+    /// the current scheme.
     pub fn funding_secret_key(
         &self,
         temporary_contract_id: [u8; 32],
     ) -> Result<SecretKey, ContractError> {
-        self.funding_secret_key_for_keys_id(self.keys_id(temporary_contract_id))
+        self.funding_secret_key_with_scheme(temporary_contract_id, KeyScheme::CURRENT)
     }
 
-    /// The funding public key for a contract — publish this in the offer or
+    /// The funding secret key for a contract under a specific scheme.
+    ///
+    /// Prefer [`funding_secret_key`](Self::funding_secret_key). Passing
+    /// `KeyScheme::V0` is a deprecation diagnostic.
+    pub fn funding_secret_key_with_scheme(
+        &self,
+        temporary_contract_id: [u8; 32],
+        scheme: KeyScheme,
+    ) -> Result<SecretKey, ContractError> {
+        self.funding_secret_key_for_keys_id(self.keys_id_with_scheme(temporary_contract_id, scheme))
+    }
+
+    /// Recovers the funding secret key of an existing contract from its
+    /// temporary id and the funding public key that was published for it.
+    ///
+    /// Tries every scheme, newest first, and returns the key whose public key
+    /// equals `funding_pubkey`. This is the entry point for anything that holds
+    /// wire messages but no stored `keys_id`, because the messages do not say
+    /// which scheme was current when the contract was made.
+    pub fn funding_secret_key_for_pubkey(
+        &self,
+        temporary_contract_id: [u8; 32],
+        funding_pubkey: &PublicKey,
+    ) -> Result<SecretKey, ContractError> {
+        for scheme in KeyScheme::ALL {
+            let secret_key = self.funding_secret_key_with_scheme(temporary_contract_id, scheme)?;
+            if secret_key.public_key(&self.secp) == *funding_pubkey {
+                return Ok(secret_key);
+            }
+        }
+        Err(ContractError::Key(format!(
+            "no key scheme derives funding pubkey {funding_pubkey} for this temporary contract id"
+        )))
+    }
+
+    /// The funding public key for a new contract — publish this in the offer or
     /// accept message ([`PartyParams::funding_pubkey`](super::PartyParams::funding_pubkey)).
     pub fn funding_pubkey(
         &self,
@@ -163,48 +334,94 @@ impl ContractKeyProvider {
     /// [`DlcInputSigningKey`] for the splice input identified by `input_serial_id`.
     /// Pass the result to [`sign_accept_spliced`](super::sign_accept_spliced) or
     /// [`finalize_sign_spliced`](super::finalize_sign_spliced).
+    ///
+    /// `prior_funding_pubkey` is this party's funding public key from the
+    /// previous contract's offer or accept message. It selects the scheme the
+    /// previous contract was made under, so contracts funded before
+    /// `2.0.0-rc.3` splice correctly. The call fails if no scheme reproduces it.
     pub fn dlc_input_signing_key(
         &self,
         prior_temporary_contract_id: [u8; 32],
+        prior_funding_pubkey: &PublicKey,
         input_serial_id: u64,
     ) -> Result<DlcInputSigningKey, ContractError> {
         Ok(DlcInputSigningKey {
             input_serial_id,
-            prior_funding_secret_key: self.funding_secret_key(prior_temporary_contract_id)?,
+            prior_funding_secret_key: self
+                .funding_secret_key_for_pubkey(prior_temporary_contract_id, prior_funding_pubkey)?,
         })
     }
 
+    /// V1: `m/420'/0'/0'/l1'/l2'/l3'`. All three contract levels are hardened
+    /// so a leaked child key plus an ancestor xpub cannot recover the parent key.
+    /// V0: `m/420'/0'/0'/l1/l2/l3`, kept only to derive keys of old contracts.
+    // Dispatches on both schemes, so it must be able to name V0.
+    #[allow(deprecated)]
     fn hierarchical_derivation_path(
         &self,
+        scheme: KeyScheme,
         level_1: u32,
         level_2: u32,
         level_3: u32,
     ) -> Result<DerivationPath, ContractError> {
         let child = |index: u32| {
-            ChildNumber::from_normal_idx(index)
-                .map_err(|e| ContractError::Key(format!("invalid derivation index: {e}")))
+            match scheme {
+                KeyScheme::V0 => ChildNumber::from_normal_idx(index),
+                KeyScheme::V1 => ChildNumber::from_hardened_idx(index),
+            }
+            .map_err(|e| ContractError::Key(format!("invalid derivation index: {e}")))
         };
         Ok(self
             .dlc_path
             .extend([child(level_1)?, child(level_2)?, child(level_3)?]))
     }
+}
 
-    fn harden(
-        &self,
-        base_key: &SecretKey,
-        level_1: u32,
-        level_2: u32,
-        level_3: u32,
-    ) -> Result<SecretKey, ContractError> {
-        let mut input = Vec::new();
-        input.extend_from_slice(self.fingerprint.as_bytes());
-        input.extend_from_slice(&base_key.secret_bytes());
-        input.extend_from_slice(&level_1.to_be_bytes());
-        input.extend_from_slice(&level_2.to_be_bytes());
-        input.extend_from_slice(&level_3.to_be_bytes());
-        SecretKey::from_slice(sha256::Hash::hash(&input).as_ref())
-            .map_err(|e| ContractError::Key(format!("invalid derived key: {e}")))
-    }
+/// V1: `SHA256( "CONTRACT_KEY_V1" || base_sk || l1 || l2 || l3 )`.
+///
+/// Defense in depth over the hardened BIP32 child: a dump of the subtree still
+/// requires one SHA-256 preimage per contract. The hash input holds the child
+/// secret, so it is wiped before returning.
+fn harden_v1(
+    base_key: &SecretKey,
+    level_1: u32,
+    level_2: u32,
+    level_3: u32,
+) -> Result<SecretKey, ContractError> {
+    harden(HARDEN_TAG_V1, base_key, level_1, level_2, level_3)
+}
+
+/// V0: `SHA256( fingerprint || base_sk || l1 || l2 || l3 )`. Kept only to
+/// derive keys of contracts funded before `2.0.0-rc.3`.
+fn harden_v0(
+    fingerprint: &Fingerprint,
+    base_key: &SecretKey,
+    level_1: u32,
+    level_2: u32,
+    level_3: u32,
+) -> Result<SecretKey, ContractError> {
+    harden(fingerprint.as_bytes(), base_key, level_1, level_2, level_3)
+}
+
+fn harden(
+    prefix: &[u8],
+    base_key: &SecretKey,
+    level_1: u32,
+    level_2: u32,
+    level_3: u32,
+) -> Result<SecretKey, ContractError> {
+    let mut base_bytes = base_key.secret_bytes();
+    let mut input = Vec::with_capacity(prefix.len() + 32 + 12);
+    input.extend_from_slice(prefix);
+    input.extend_from_slice(&base_bytes);
+    input.extend_from_slice(&level_1.to_be_bytes());
+    input.extend_from_slice(&level_2.to_be_bytes());
+    input.extend_from_slice(&level_3.to_be_bytes());
+    let digest = sha256::Hash::hash(&input).to_byte_array();
+    input.zeroize();
+    base_bytes.zeroize();
+    SecretKey::from_slice(&digest)
+        .map_err(|e| ContractError::Key(format!("invalid derived key: {e}")))
 }
 
 /// Splits the first 12 bytes of a `keys_id` into three level indices.
@@ -223,7 +440,7 @@ fn hierarchical_indices(keys_id: [u8; 32]) -> (u32, u32, u32) {
 impl ddk_manager::ContractSignerProvider for ContractKeyProvider {
     type Signer = SimpleSigner;
 
-    fn derive_signer_key_id(&self, _is_offer_party: bool, temp_id: [u8; 32]) -> [u8; 32] {
+    fn derive_signer_key_id(&self, temp_id: [u8; 32]) -> [u8; 32] {
         self.keys_id(temp_id)
     }
 
@@ -250,16 +467,209 @@ impl ddk_manager::ContractSignerProvider for ContractKeyProvider {
 }
 
 #[cfg(test)]
+// The tests name V0 on purpose: they pin the legacy scheme so old contracts
+// keep unlocking. Production code must not do this.
+#[allow(deprecated)]
 mod tests {
     use super::*;
+    use ddk_manager::{ContractSigner, ContractSignerProvider};
 
     const TEMP_A: [u8; 32] = [0xA1; 32];
     const TEMP_B: [u8; 32] = [0xB2; 32];
     const MNEMONIC: &str =
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
+    /// Test vectors for `MNEMONIC` (no passphrase, regtest) and `TEMP_A`.
+    ///
+    /// The V0 values were produced by the V0 code shipped in `2.0.0-rc.2`. They
+    /// pin the pre-hardening scheme so `v0_reference` below is known to be a
+    /// faithful re-implementation, and so old contracts keep deriving the same
+    /// key. The V1 values pin the current scheme against accidental drift.
+    const V0_KEYS_ID: &str = "a7649d1c927f2b8af024e9a1d3b59c84da975629a2c3805f16afa19090ab6115";
+    const V0_FUNDING_PK: &str =
+        "03aa70703dca189d6df5cc73408d2e96f4c3f3a761f4889653984b8a694956a35a";
+    const V1_KEYS_ID: &str = "5604be211579c6a4c28fa5e61ce059ae4f4716c2bee2da0f44444b4b45597631";
+    const V1_FUNDING_PK: &str =
+        "03c952c4c3a4f7b69ab23bbc8d1d6f1a1487beca22edeb32c3116f82ac8aca7159";
+
     fn provider() -> ContractKeyProvider {
         ContractKeyProvider::from_mnemonic(MNEMONIC, None, Network::Regtest).unwrap()
+    }
+
+    fn pk(hex_str: &str) -> PublicKey {
+        PublicKey::from_str(hex_str).unwrap()
+    }
+
+    /// The V0 scheme, re-implemented verbatim from `2.0.0-rc.2`: V0 keys-id
+    /// tag, non-hardened contract levels, and the wallet fingerprint (not a
+    /// tag) in the final hash. Independent of the production V0 code path.
+    fn v0_reference(keys: &ContractKeyProvider, temp_id: [u8; 32]) -> ([u8; 32], SecretKey) {
+        let mut input = Vec::new();
+        input.extend_from_slice(keys.fingerprint.as_bytes());
+        input.extend_from_slice(&temp_id);
+        input.extend_from_slice(b"CONTRACT_SIGNER_KEY_ID_V0");
+        let keys_id = sha256::Hash::hash(&input).to_byte_array();
+
+        let (l1, l2, l3) = hierarchical_indices(keys_id);
+        let path = keys.dlc_path.extend([
+            ChildNumber::from_normal_idx(l1).unwrap(),
+            ChildNumber::from_normal_idx(l2).unwrap(),
+            ChildNumber::from_normal_idx(l3).unwrap(),
+        ]);
+        let base = keys
+            .xprv
+            .derive_priv(&keys.secp, &path)
+            .unwrap()
+            .private_key;
+
+        let mut input = Vec::new();
+        input.extend_from_slice(keys.fingerprint.as_bytes());
+        input.extend_from_slice(&base.secret_bytes());
+        input.extend_from_slice(&l1.to_be_bytes());
+        input.extend_from_slice(&l2.to_be_bytes());
+        input.extend_from_slice(&l3.to_be_bytes());
+        let sk = SecretKey::from_slice(sha256::Hash::hash(&input).as_ref()).unwrap();
+        (keys_id, sk)
+    }
+
+    #[test]
+    fn v0_reference_matches_the_shipped_v0_vectors() {
+        let keys = provider();
+        let (keys_id, sk) = v0_reference(&keys, TEMP_A);
+        assert_eq!(hex::encode(keys_id), V0_KEYS_ID);
+        assert_eq!(sk.public_key(&keys.secp).to_string(), V0_FUNDING_PK);
+    }
+
+    #[test]
+    fn v1_vectors_are_pinned() {
+        let keys = provider();
+        assert_eq!(hex::encode(keys.keys_id(TEMP_A)), V1_KEYS_ID);
+        assert_eq!(
+            keys.funding_pubkey(TEMP_A).unwrap().to_string(),
+            V1_FUNDING_PK
+        );
+        assert_eq!(KeyScheme::CURRENT, KeyScheme::V1);
+        assert_eq!(
+            keys.keys_id_with_scheme(TEMP_A, KeyScheme::V1),
+            keys.keys_id(TEMP_A)
+        );
+    }
+
+    #[test]
+    fn v0_scheme_is_still_derivable_from_a_temp_id() {
+        // Backwards compatibility: the production V0 path must reproduce the
+        // keys that 2.0.0-rc.2 produced, from the temp id alone.
+        let keys = provider();
+        let keys_id = keys.keys_id_with_scheme(TEMP_A, KeyScheme::V0);
+        assert_eq!(hex::encode(keys_id), V0_KEYS_ID);
+        assert_eq!(
+            keys.funding_secret_key_with_scheme(TEMP_A, KeyScheme::V0)
+                .unwrap()
+                .public_key(&keys.secp),
+            pk(V0_FUNDING_PK)
+        );
+        for temp_id in [TEMP_A, TEMP_B, [0u8; 32], [0xFF; 32]] {
+            let (v0_keys_id, v0_sk) = v0_reference(&keys, temp_id);
+            assert_eq!(keys.keys_id_with_scheme(temp_id, KeyScheme::V0), v0_keys_id);
+            assert_eq!(
+                keys.funding_secret_key_with_scheme(temp_id, KeyScheme::V0)
+                    .unwrap(),
+                v0_sk
+            );
+        }
+    }
+
+    #[test]
+    fn a_stored_v0_keys_id_derives_the_v0_key() {
+        // Backwards compatibility for the manager path: a keys_id persisted by
+        // an earlier release is fed straight to derive_contract_signer and must
+        // give the key that funded the contract.
+        let keys = provider();
+        let stored: [u8; 32] = hex::decode(V0_KEYS_ID).unwrap().try_into().unwrap();
+        assert_eq!(KeyScheme::of_keys_id(&stored), KeyScheme::V0);
+        assert_eq!(
+            keys.funding_secret_key_for_keys_id(stored)
+                .unwrap()
+                .public_key(&keys.secp),
+            pk(V0_FUNDING_PK)
+        );
+        let signer = keys.derive_contract_signer(stored).unwrap();
+        assert_eq!(
+            signer.get_public_key(&keys.secp).unwrap(),
+            pk(V0_FUNDING_PK)
+        );
+    }
+
+    #[test]
+    fn a_new_keys_id_derives_the_v1_key() {
+        let keys = provider();
+        let keys_id = keys.derive_signer_key_id(TEMP_A);
+        assert_eq!(KeyScheme::of_keys_id(&keys_id), KeyScheme::V1);
+        assert_eq!(&keys_id[24..32], KEYS_ID_V1_MARKER);
+        let signer = keys.derive_contract_signer(keys_id).unwrap();
+        assert_eq!(
+            signer.get_public_key(&keys.secp).unwrap(),
+            pk(V1_FUNDING_PK)
+        );
+    }
+
+    #[test]
+    fn v1_keys_differ_from_v0_keys_for_the_same_temp_id() {
+        // Pins the migration boundary: the two schemes never collide, so a
+        // key can always be attributed to exactly one of them.
+        let keys = provider();
+        for temp_id in [TEMP_A, TEMP_B, [0u8; 32], [0xFF; 32]] {
+            let (v0_keys_id, v0_sk) = v0_reference(&keys, temp_id);
+            assert_ne!(keys.keys_id(temp_id), v0_keys_id);
+            assert_ne!(keys.funding_secret_key(temp_id).unwrap(), v0_sk);
+        }
+    }
+
+    #[test]
+    fn funding_secret_key_for_pubkey_resolves_either_scheme() {
+        let keys = provider();
+        let v1 = keys
+            .funding_secret_key_for_pubkey(TEMP_A, &pk(V1_FUNDING_PK))
+            .unwrap();
+        assert_eq!(v1, keys.funding_secret_key(TEMP_A).unwrap());
+        let v0 = keys
+            .funding_secret_key_for_pubkey(TEMP_A, &pk(V0_FUNDING_PK))
+            .unwrap();
+        assert_eq!(
+            v0,
+            keys.funding_secret_key_with_scheme(TEMP_A, KeyScheme::V0)
+                .unwrap()
+        );
+        // A pubkey from another contract (or another wallet) is an error, not a
+        // silently wrong key.
+        let other = keys.funding_pubkey(TEMP_B).unwrap();
+        assert!(matches!(
+            keys.funding_secret_key_for_pubkey(TEMP_A, &other),
+            Err(ContractError::Key(_))
+        ));
+    }
+
+    #[test]
+    fn dlc_input_signing_key_recovers_the_prior_key_under_either_scheme() {
+        let keys = provider();
+        let v1 = keys
+            .dlc_input_signing_key(TEMP_A, &pk(V1_FUNDING_PK), 900)
+            .unwrap();
+        assert_eq!(v1.input_serial_id, 900);
+        assert_eq!(
+            v1.prior_funding_secret_key,
+            keys.funding_secret_key(TEMP_A).unwrap()
+        );
+        let v0 = keys
+            .dlc_input_signing_key(TEMP_A, &pk(V0_FUNDING_PK), 901)
+            .unwrap();
+        assert_eq!(
+            v0.prior_funding_secret_key.public_key(&keys.secp),
+            pk(V0_FUNDING_PK)
+        );
+        assert!(keys
+            .dlc_input_signing_key(TEMP_A, &keys.funding_pubkey(TEMP_B).unwrap(), 902)
+            .is_err());
     }
 
     #[test]
@@ -278,17 +688,6 @@ mod tests {
         let secp = Secp256k1::new();
         let sk = keys.funding_secret_key(TEMP_A).unwrap();
         assert_eq!(keys.funding_pubkey(TEMP_A).unwrap(), sk.public_key(&secp));
-    }
-
-    #[test]
-    fn dlc_input_signing_key_carries_the_recovered_prior_key() {
-        let keys = provider();
-        let signing_key = keys.dlc_input_signing_key(TEMP_A, 900).unwrap();
-        assert_eq!(signing_key.input_serial_id, 900);
-        assert_eq!(
-            signing_key.prior_funding_secret_key,
-            keys.funding_secret_key(TEMP_A).unwrap()
-        );
     }
 
     #[test]
@@ -348,40 +747,93 @@ mod tests {
     }
 
     #[test]
-    fn derivation_path_is_base_plus_three_levels() {
-        use bitcoin::bip32::ChildNumber;
+    fn v1_derivation_path_is_base_plus_three_hardened_levels() {
         let keys = provider();
         let (l1, l2, l3) = hierarchical_indices([1u8; 32]);
-        let path = keys.hierarchical_derivation_path(l1, l2, l3).unwrap();
+        let path = keys
+            .hierarchical_derivation_path(KeyScheme::V1, l1, l2, l3)
+            .unwrap();
         assert_eq!(path.len(), 6);
         assert_eq!(path[0], ChildNumber::from_hardened_idx(420).unwrap());
         assert_eq!(path[1], ChildNumber::from_hardened_idx(0).unwrap());
         assert_eq!(path[2], ChildNumber::from_hardened_idx(0).unwrap());
+        assert_eq!(path[3], ChildNumber::from_hardened_idx(l1).unwrap());
+        assert_eq!(path[4], ChildNumber::from_hardened_idx(l2).unwrap());
+        assert_eq!(path[5], ChildNumber::from_hardened_idx(l3).unwrap());
+        assert!(path.into_iter().all(|child| child.is_hardened()));
+    }
+
+    #[test]
+    fn v0_derivation_path_keeps_normal_contract_levels() {
+        let keys = provider();
+        let (l1, l2, l3) = hierarchical_indices([1u8; 32]);
+        let path = keys
+            .hierarchical_derivation_path(KeyScheme::V0, l1, l2, l3)
+            .unwrap();
         assert_eq!(path[3], ChildNumber::from_normal_idx(l1).unwrap());
         assert_eq!(path[4], ChildNumber::from_normal_idx(l2).unwrap());
         assert_eq!(path[5], ChildNumber::from_normal_idx(l3).unwrap());
     }
 
     #[test]
-    fn hardening_is_deterministic_and_sensitive() {
+    fn hardened_levels_block_the_xpub_walk_up() {
+        use bitcoin::bip32::Xpub;
+        // With hardened contract levels, the xpub at the base path cannot
+        // derive the contract child public keys at all: the attack in the audit
+        // (child sk + parent xpub => parent sk) has no non-hardened step to use.
         let keys = provider();
+        let base_xpub = Xpub::from_priv(
+            &keys.secp,
+            &keys.xprv.derive_priv(&keys.secp, &keys.dlc_path).unwrap(),
+        );
+        let (l1, l2, l3) = hierarchical_indices(keys.keys_id(TEMP_A));
+        let hardened = [
+            ChildNumber::from_hardened_idx(l1).unwrap(),
+            ChildNumber::from_hardened_idx(l2).unwrap(),
+            ChildNumber::from_hardened_idx(l3).unwrap(),
+        ];
+        assert!(base_xpub.derive_pub(&keys.secp, &hardened).is_err());
+    }
+
+    #[test]
+    fn hardening_is_deterministic_and_sensitive() {
         let base = SecretKey::from_slice(&[0x42; 32]).unwrap();
         assert_eq!(
-            keys.harden(&base, 100, 200, 300).unwrap(),
-            keys.harden(&base, 100, 200, 300).unwrap()
+            harden_v1(&base, 100, 200, 300).unwrap(),
+            harden_v1(&base, 100, 200, 300).unwrap()
         );
-        assert_ne!(keys.harden(&base, 100, 200, 300).unwrap(), base);
+        assert_ne!(harden_v1(&base, 100, 200, 300).unwrap(), base);
         assert_ne!(
-            keys.harden(&base, 100, 200, 300).unwrap(),
-            keys.harden(&base, 100, 200, 301).unwrap()
-        );
-        assert_ne!(
-            keys.harden(&base, 100, 200, 300).unwrap(),
-            keys.harden(&base, 100, 201, 300).unwrap()
+            harden_v1(&base, 100, 200, 300).unwrap(),
+            harden_v1(&base, 100, 200, 301).unwrap()
         );
         assert_ne!(
-            keys.harden(&base, 100, 200, 300).unwrap(),
-            keys.harden(&base, 101, 200, 300).unwrap()
+            harden_v1(&base, 100, 200, 300).unwrap(),
+            harden_v1(&base, 100, 201, 300).unwrap()
+        );
+        assert_ne!(
+            harden_v1(&base, 100, 200, 300).unwrap(),
+            harden_v1(&base, 101, 200, 300).unwrap()
+        );
+    }
+
+    #[test]
+    fn hardening_is_domain_tagged() {
+        // The V1 hash is over the tag, not the fingerprint, and is exactly
+        // SHA256(tag || base || l1 || l2 || l3).
+        let base = SecretKey::from_slice(&[0x42; 32]).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"CONTRACT_KEY_V1");
+        expected.extend_from_slice(&[0x42; 32]);
+        expected.extend_from_slice(&1u32.to_be_bytes());
+        expected.extend_from_slice(&2u32.to_be_bytes());
+        expected.extend_from_slice(&3u32.to_be_bytes());
+        let expected = SecretKey::from_slice(sha256::Hash::hash(&expected).as_ref()).unwrap();
+        assert_eq!(harden_v1(&base, 1, 2, 3).unwrap(), expected);
+        let fingerprint = provider().fingerprint;
+        assert_ne!(
+            harden_v0(&fingerprint, &base, 1, 2, 3).unwrap(),
+            harden_v1(&base, 1, 2, 3).unwrap()
         );
     }
 

--- a/ddk/src/contract/mod.rs
+++ b/ddk/src/contract/mod.rs
@@ -157,7 +157,7 @@ pub use accept::{accept_offer, create_dlc_transactions};
 pub use create::{create_offer, validate_offer};
 pub use error::ContractError;
 pub use finalize::{finalize_sign, finalize_sign_spliced};
-pub use keys::ContractKeyProvider;
+pub use keys::{ContractKeyProvider, KeyScheme};
 pub use psbt::create_funding_psbt;
 pub use settle::{sign_cet, sign_refund};
 pub use sign::{sign_accept, sign_accept_spliced};

--- a/ddk/src/lib.rs
+++ b/ddk/src/lib.rs
@@ -1,6 +1,9 @@
 //! application tooling for DLCs 🌊
 // #![doc = include_str!("../README.md")]
 #![allow(clippy::result_large_err)]
+// Deprecated items are unlock-only compatibility paths (see
+// `contract::KeyScheme::V0`). Naming one is a hard error in this crate.
+#![deny(deprecated)]
 
 /// Stateless DLC contract operations.
 ///

--- a/ddk/src/wallet/mod.rs
+++ b/ddk/src/wallet/mod.rs
@@ -682,22 +682,14 @@ impl FeeEstimator for DlcDevKitWallet {
 impl ddk_manager::ContractSignerProvider for DlcDevKitWallet {
     type Signer = SimpleSigner;
 
-    /// Generates a deterministic key ID for contract signing.
+    /// Generates a deterministic key ID for contract signing by delegating to
+    /// the [`ContractKeyProvider`].
     ///
-    /// This method creates a unique key identifier for each contract by hashing
-    /// the temporary contract ID with random bytes. The resulting key ID is used
-    /// to derive signing keys for the specific contract.
-    ///
-    /// # Arguments
-    /// * `_is_offer_party` - Whether this party is the offer party (currently unused)
-    /// * `temp_id` - Temporary contract ID from the DLC protocol
-    ///
-    /// # Returns
-    /// A 32-byte key ID for the contract
+    /// The key ID is `SHA256(fingerprint || temp_id || tag)`, so the same
+    /// temporary contract ID gives a different key ID in every wallet.
     #[tracing::instrument(skip(self))]
-    fn derive_signer_key_id(&self, is_offer_party: bool, temp_id: [u8; 32]) -> [u8; 32] {
-        self.contract_keys
-            .derive_signer_key_id(is_offer_party, temp_id)
+    fn derive_signer_key_id(&self, temp_id: [u8; 32]) -> [u8; 32] {
+        self.contract_keys.derive_signer_key_id(temp_id)
     }
 
     /// Creates a contract signer from a key ID by delegating to the
@@ -977,7 +969,7 @@ mod tests {
         temp_key_id
             .try_fill(&mut bitcoin::key::rand::thread_rng())
             .unwrap();
-        let gen_key_id = test.derive_signer_key_id(true, temp_key_id);
+        let gen_key_id = test.derive_signer_key_id(temp_key_id);
         let key_info = test.derive_contract_signer(gen_key_id);
         assert!(key_info.is_ok())
     }
@@ -1016,13 +1008,10 @@ mod tests {
 
         let temp_id = [0x55; 32];
 
-        // Test both offer party values produce same result (since _is_offer_party is unused)
-        let key_id1 = wallet.derive_signer_key_id(true, temp_id);
-        let key_id2 = wallet.derive_signer_key_id(false, temp_id);
-        let key_id3 = wallet.derive_signer_key_id(true, temp_id); // repeat with same params
+        let key_id1 = wallet.derive_signer_key_id(temp_id);
+        let key_id2 = wallet.derive_signer_key_id(temp_id);
 
-        assert_eq!(key_id1, key_id2); // is_offer_party doesn't affect result
-        assert_eq!(key_id1, key_id3); // deterministic
+        assert_eq!(key_id1, key_id2); // deterministic
     }
 
     #[tokio::test]
@@ -1032,8 +1021,8 @@ mod tests {
         let temp_id1 = [0x11; 32];
         let temp_id2 = [0x22; 32];
 
-        let key_id1 = wallet.derive_signer_key_id(true, temp_id1);
-        let key_id2 = wallet.derive_signer_key_id(true, temp_id2);
+        let key_id1 = wallet.derive_signer_key_id(temp_id1);
+        let key_id2 = wallet.derive_signer_key_id(temp_id2);
 
         // Different temp_ids should produce different key_ids
         assert_ne!(key_id1, key_id2);
@@ -1047,8 +1036,8 @@ mod tests {
         let temp_id = [0x99; 32];
 
         // Same temp_id should produce different key_ids for different wallets
-        let key_id1 = wallet1.derive_signer_key_id(true, temp_id);
-        let key_id2 = wallet2.derive_signer_key_id(true, temp_id);
+        let key_id1 = wallet1.derive_signer_key_id(temp_id);
+        let key_id2 = wallet2.derive_signer_key_id(temp_id);
 
         assert_ne!(
             key_id1, key_id2,
@@ -1061,7 +1050,7 @@ mod tests {
         let wallet = create_wallet().await;
 
         let temp_id = [0x77; 32];
-        let key_id = wallet.derive_signer_key_id(true, temp_id);
+        let key_id = wallet.derive_signer_key_id(temp_id);
         let signer = wallet
             .derive_contract_signer(key_id)
             .expect("Should create valid signer");
@@ -1089,11 +1078,11 @@ mod tests {
         let temp_id = [0xAB; 32];
 
         // Full workflow: temp_id -> key_id -> signer
-        let key_id = wallet.derive_signer_key_id(true, temp_id);
+        let key_id = wallet.derive_signer_key_id(temp_id);
         let signer1 = wallet.derive_contract_signer(key_id).unwrap();
 
         // Repeat the workflow
-        let key_id2 = wallet.derive_signer_key_id(true, temp_id);
+        let key_id2 = wallet.derive_signer_key_id(temp_id);
         let signer2 = wallet.derive_contract_signer(key_id2).unwrap();
 
         // Everything should be identical
@@ -1111,8 +1100,8 @@ mod tests {
         let temp_id1 = [0x01; 32];
         let temp_id2 = [0x02; 32];
 
-        let key_id1 = wallet.derive_signer_key_id(true, temp_id1);
-        let key_id2 = wallet.derive_signer_key_id(true, temp_id2);
+        let key_id1 = wallet.derive_signer_key_id(temp_id1);
+        let key_id2 = wallet.derive_signer_key_id(temp_id2);
         let signer1 = wallet.derive_contract_signer(key_id1).unwrap();
         let signer2 = wallet.derive_contract_signer(key_id2).unwrap();
 
@@ -1135,7 +1124,7 @@ mod tests {
             let mut temp_id = [0u8; 32];
             temp_id[0..4].copy_from_slice(&i.to_be_bytes());
 
-            let key_id = wallet.derive_signer_key_id(true, temp_id);
+            let key_id = wallet.derive_signer_key_id(temp_id);
             let signer = wallet.derive_contract_signer(key_id).unwrap();
             let public_key = signer.get_public_key(&wallet.secp).unwrap();
 
@@ -1162,7 +1151,7 @@ mod tests {
 
         // Simulate creating a contract
         let temp_id = [0xDE, 0xAD, 0xBE, 0xEF].repeat(8).try_into().unwrap();
-        let key_id = wallet.derive_signer_key_id(true, temp_id);
+        let key_id = wallet.derive_signer_key_id(temp_id);
         let original_signer = wallet.derive_contract_signer(key_id).unwrap();
         let target_public_key = original_signer.get_public_key(&wallet.secp).unwrap();
 
@@ -1176,7 +1165,7 @@ mod tests {
         );
 
         // Also test that we can recover from just the temp_id
-        let recovered_key_id = wallet.derive_signer_key_id(true, temp_id);
+        let recovered_key_id = wallet.derive_signer_key_id(temp_id);
         let temp_id_recovered_signer = wallet.derive_contract_signer(recovered_key_id).unwrap();
 
         assert_eq!(key_id, recovered_key_id);

--- a/ddk/tests/stateless_utils.rs
+++ b/ddk/tests/stateless_utils.rs
@@ -817,16 +817,22 @@ impl TestParty {
     /// Recovers this party's funding key for a *previous* contract, so it can
     /// sign that contract's 2-of-2 output when splicing.
     ///
-    /// Providers recompute the key from the previous temporary contract id;
-    /// a raw key is simply the one the party already holds.
+    /// Providers recompute the key from the previous temporary contract id and
+    /// the funding pubkey published in the previous contract's messages; a raw
+    /// key is simply the one the party already holds.
     pub fn dlc_input_signing_key(
         &self,
         prior_temporary_contract_id: [u8; 32],
+        prior_funding_pubkey: &PublicKey,
         input_serial_id: u64,
     ) -> DlcInputSigningKey {
         match &self.contract_keys {
             Some(keys) => keys
-                .dlc_input_signing_key(prior_temporary_contract_id, input_serial_id)
+                .dlc_input_signing_key(
+                    prior_temporary_contract_id,
+                    prior_funding_pubkey,
+                    input_serial_id,
+                )
                 .unwrap(),
             None => DlcInputSigningKey {
                 input_serial_id,
@@ -1124,6 +1130,19 @@ pub fn splice_from(
     accepter: &TestParty,
     input_serial_id: u64,
 ) -> SpliceSetup {
+    // The keys travel with the roles (see `splice_setup_by`): when the accept
+    // party splices, `offerer` is the previous accepter, so its previous
+    // funding pubkey is the one from the previous accept message.
+    let (offerer_prior_pubkey, accepter_prior_pubkey) = match splicer {
+        Party::Offer => (
+            previous.offer.funding_pubkey,
+            previous.accept.funding_pubkey,
+        ),
+        Party::Accept => (
+            previous.accept.funding_pubkey,
+            previous.offer.funding_pubkey,
+        ),
+    };
     SpliceSetup {
         funding_input: create_dlc_splice_input(
             &previous.offer,
@@ -1133,8 +1152,16 @@ pub fn splice_from(
             DLC_INPUT_MAX_WITNESS_LEN,
         )
         .unwrap(),
-        offer_key: offerer.dlc_input_signing_key(previous.temporary_contract_id, input_serial_id),
-        accept_key: accepter.dlc_input_signing_key(previous.temporary_contract_id, input_serial_id),
+        offer_key: offerer.dlc_input_signing_key(
+            previous.temporary_contract_id,
+            &offerer_prior_pubkey,
+            input_serial_id,
+        ),
+        accept_key: accepter.dlc_input_signing_key(
+            previous.temporary_contract_id,
+            &accepter_prior_pubkey,
+            input_serial_id,
+        ),
     }
 }
 

--- a/docs/contract-key-derivation.md
+++ b/docs/contract-key-derivation.md
@@ -1,342 +1,183 @@
-# Hierarchical Deterministic Key Derivation for Large-Scale DLC Contracts
+# Contract Key Derivation
 
-## Overview
+Scheme versions: **V1** is current (from `2.0.0-rc.3`). **V0** (all earlier
+releases) stays fully supported. A node upgraded in place keeps signing,
+settling, and splicing its V0 contracts, and makes V1 keys for new contracts.
 
-This document explains how our DLC (Discreet Log Contract) implementation achieves collision-resistant deterministic key derivation that scales to millions of contracts while maintaining complete recoverability. The system transforms the fundamental challenge of managing massive numbers of unique contract keys from a database storage problem into an elegant mathematical derivation problem.
+Code: `ddk/src/contract/keys.rs` (`ContractKeyProvider`, `KeyScheme`).
+`DlcDevKitWallet` delegates to the same type, so the manager path and the
+stateless API derive identical keys.
 
-The core innovation lies in leveraging Bitcoin's Hierarchical Deterministic (HD) wallet infrastructure to create multiple levels of key derivation, giving us an enormous effective key space that eliminates hash collisions while remaining completely deterministic and recoverable. This approach allows our system to handle millions of contracts without requiring external databases or cached key storage, while still providing mathematically guaranteed recovery mechanisms for disaster scenarios.
+## Purpose
 
-Understanding this system requires grasping how we balance three critical requirements that typically conflict with each other: collision resistance for millions of contracts, stateless deterministic derivation, and practical disaster recovery capabilities. The elegant mathematical solution we present here shows how hierarchical key derivation can satisfy all three requirements simultaneously.
+Each DLC contract has one *funding key*. It controls the 2-of-2 funding output,
+signs the CET adaptor signatures, and signs the refund transaction. DDK does not
+store funding keys. It derives each key on demand from two inputs:
 
-## The Scale Challenge: Moving from Thousands to Millions
+- the wallet's master extended private key (`xprv`)
+- the contract's temporary contract id (`temp_id`, 32 random bytes from the
+  `OfferDlc`)
 
-Traditional deterministic key derivation systems work well for smaller numbers of contracts, but they encounter fundamental mathematical limits when scaling to millions of contracts. The birthday paradox, a well-known phenomenon in probability theory, explains why collision-free systems become much more complex at scale than our intuition suggests.
+The same inputs always give the same key. A wallet restored from its seed can
+re-derive every contract key it ever used.
 
-To understand this challenge, consider that with a simple single-level derivation system using ten million possible key locations, you would expect to encounter your first collision after creating only about 3,162 contracts. This happens because the probability of collision grows quadratically with the number of contracts, not linearly as we might expect. By the time you reach hundreds of thousands of contracts, collisions become virtually guaranteed rather than merely probable.
+## Derivation
 
-This mathematical reality means that any system designed to handle millions of DLC contracts must fundamentally expand beyond single-level key derivation. The solution lies in recognizing that Bitcoin's HD derivation system naturally supports multiple levels of hierarchy, and we can leverage this structure to create key spaces that are astronomically larger than what single-level systems can provide.
+```text
+fingerprint = BIP32 fingerprint of the master xprv (4 bytes)
 
-## Hierarchical Key Derivation Architecture
+V1 (current)
+  keys_id   = SHA256( fingerprint || temp_id || "CONTRACT_SIGNER_KEY_ID_V1" )[0..24] || "DDKKEYv1"
+  l1        = u32_be( keys_id[0..4] )  mod 3400
+  l2        = u32_be( keys_id[4..8] )  mod 3400
+  l3        = u32_be( keys_id[8..12] ) mod 3400
+  base_sk   = private key at  m/420'/0'/0'/l1'/l2'/l3'
+  sk        = SHA256( "CONTRACT_KEY_V1" || base_sk || u32_be(l1) || u32_be(l2) || u32_be(l3) )
 
-Our solution transforms the key derivation process from a single hash-to-index mapping into a hierarchical tree structure that provides multiple levels of collision resistance. Instead of trying to fit millions of contracts into a single dimensional space, we create a three-dimensional space where each dimension provides its own collision-resistant namespace.
-
-The fundamental insight is that we can extract multiple derivation indices from each key identifier, using different portions of the cryptographic hash to determine different levels of the derivation path. This approach maintains complete determinism while expanding our effective key space from millions to billions of possible locations.
-
-Think of this like the difference between organizing books on a single bookshelf versus organizing them in a multi-story library with multiple wings and sections. The single bookshelf quickly becomes overcrowded and difficult to organize without conflicts, while the multi-story library can accommodate millions of books with sophisticated organizational systems that prevent any conflicts.
-
-## Step 1: Hierarchical Key ID Generation
-
-The first step in our improved system creates key identifiers that encode hierarchical derivation information. This process generates a deterministic 32-byte identifier that will be interpreted as containing multiple derivation indices rather than a single index.
-
-```rust
-/// Generates a deterministic key ID for contract signing.
-///
-/// This method creates a unique key identifier for each contract by hashing
-/// the temporary contract ID with wallet fingerprint. The resulting key ID is used
-/// to derive signing keys for the specific contract.
-///
-/// # Arguments
-/// * `_is_offer_party` - Whether this party is the offer party (currently unused)
-/// * `temp_id` - Temporary contract ID from the DLC protocol
-///
-/// # Returns
-/// A 32-byte key ID for the contract
-fn derive_signer_key_id(&self, _is_offer_party: bool, temp_id: [u8; 32]) -> [u8; 32] {
-    let mut key_id_input = Vec::new();
-    key_id_input.extend_from_slice(self.fingerprint.as_bytes());
-    key_id_input.extend_from_slice(&temp_id);
-    key_id_input.extend_from_slice(b"CONTRACT_SIGNER_KEY_ID_V1");
-    let key_id_hash = sha256::Hash::hash(&key_id_input);
-    key_id_hash.to_byte_array()
-}
+V0 (releases before 2.0.0-rc.3)
+  keys_id   = SHA256( fingerprint || temp_id || "CONTRACT_SIGNER_KEY_ID_V0" )
+  l1,l2,l3  = as above
+  base_sk   = private key at  m/420'/0'/0'/l1/l2/l3          (levels NOT hardened)
+  sk        = SHA256( fingerprint || base_sk || u32_be(l1) || u32_be(l2) || u32_be(l3) )
 ```
 
-The critical components of this implementation are the wallet fingerprint integration and the version string. The fingerprint ensures that identical temporary contract IDs produce completely different key identifiers across different wallet instances, preventing any cross-wallet key reuse attacks. The SHA256 hash operation provides excellent avalanche properties, meaning that small changes in the temporary contract ID result in completely different values across all bytes of the resulting key identifier.
-
-This property becomes crucial when we extract multiple derivation indices from different portions of the same hash. The version string provides protection against future protocol changes and ensures compatibility between different implementations of the hierarchical derivation system.
-
-## Step 2: Extracting Multiple Derivation Indices
-
-The hierarchical approach transforms our key identifier interpretation from a single index extraction into a multi-level index extraction process. We divide the key identifier into multiple segments, with each segment determining a different level of the HD derivation path. This implementation uses the first 12 bytes of our 32-byte key identifier to create three independent derivation indices.
-
-```rust
-/// Converts a 32-byte key ID into hierarchical indices for derivation paths.
-///
-/// This function takes a 32-byte key ID and splits it into three 4-byte
-/// arrays, which are then used to calculate indices for three levels of
-/// derivation paths. The indices are calculated using modulo arithmetic
-/// to ensure they fall within the range of 0 to 3399.
-fn key_id_to_hierarchical_indices(&self, key_id: [u8; 32]) -> (u32, u32, u32) {
-    let level_1 = [key_id[0], key_id[1], key_id[2], key_id[3]];
-    let level_2 = [key_id[4], key_id[5], key_id[6], key_id[7]];
-    let level_3 = [key_id[8], key_id[9], key_id[10], key_id[11]];
-    let level_1_index = u32::from_be_bytes(level_1) % 3_400;
-    let level_2_index = u32::from_be_bytes(level_2) % 3_400;
-    let level_3_index = u32::from_be_bytes(level_3) % 3_400;
-    // Total combination space: 3400 × 3400 × 3400 = ~39.3 billion possible paths
-    (level_1_index, level_2_index, level_3_index)
-}
-```
-
-This extraction process demonstrates a sophisticated understanding of cryptographic hash distribution properties. Because the SHA256 hash provides excellent avalanche effects, each 4-byte segment of the key identifier contains essentially independent entropy. This means that the three derivation indices we extract are statistically independent of each other, providing maximum collision resistance across all levels of the hierarchy.
-
-The modulo operations constrain each level to 3,400 possible values, creating a total combination space of approximately 39.3 billion possible derivation paths. This represents an enormous expansion from single-level systems while maintaining practical disaster recovery capabilities, as we will explore in the security analysis section.
-
-## Step 3: Building Hierarchical Derivation Paths
-
-With our three derivation indices extracted from the first 12 bytes of the key identifier, we construct the complete HD derivation path that will be used to generate the base secret key. This implementation demonstrates how each of the three indices becomes a separate level in the Bitcoin HD derivation path.
-
-```rust
-fn get_hierarchical_derivation_path(&self, key_id: [u8; 32]) -> Result<DerivationPath> {
-    let (level_1_index, level_2_index, level_3_index) =
-        self.key_id_to_hierarchical_indices(key_id);
-    let child_one = ChildNumber::from_normal_idx(level_1_index)
-        .map_err(|_| WalletError::InvalidDerivationIndex)?;
-    let child_two = ChildNumber::from_normal_idx(level_2_index)
-        .map_err(|_| WalletError::InvalidDerivationIndex)?;
-    let child_three = ChildNumber::from_normal_idx(level_3_index)
-        .map_err(|_| WalletError::InvalidDerivationIndex)?;
-    let path = self.dlc_path.clone();
-    let full_path = path.extend([child_one, child_two, child_three]);
-    Ok(full_path)
-}
-```
-
-The resulting derivation path creates a systematic organization within your wallet's HD tree that is both collision-resistant and completely deterministic. The base `dlc_path` (typically `m/9999'/0'/0'`) provides hardened derivation steps that offer additional security by making it impossible to derive parent keys from child keys, even if an attacker gained access to multiple contract keys.
-
-The three additional levels create what cryptographers call a "tree of trees" structure, where each branch point provides its own collision-resistant namespace. The final path structure becomes something like `m/9999'/0'/0'/1234/5678/9012`, where each number represents one of our extracted hierarchical indices.
-
-This hierarchical organization means that even if there were collisions at one level, they would be distributed across different branches of the tree, preventing actual key collisions in the final derived keys.
-
-## Step 4: Enhanced Hierarchical Hardening
-
-The hardening function for hierarchical derivation incorporates all three levels of derivation indices, creating maximum entropy and security for the final key generation process. This approach provides defense against sophisticated attacks while maintaining the recoverability properties essential for disaster recovery.
-
-```rust
-fn apply_hardening_to_base_key(
-    &self,
-    base_key: &SecretKey,
-    level_1: u32,
-    level_2: u32,
-    level_3: u32,
-) -> Result<SecretKey> {
-    let mut hardening_input = Vec::new();
-    hardening_input.extend_from_slice(self.fingerprint.as_bytes());
-    hardening_input.extend_from_slice(&base_key.secret_bytes());
-    hardening_input.extend_from_slice(&level_1.to_be_bytes());
-    hardening_input.extend_from_slice(&level_2.to_be_bytes());
-    hardening_input.extend_from_slice(&level_3.to_be_bytes());
-    let hardened_hash = sha256::Hash::hash(&hardening_input);
-    SecretKey::from_slice(&hardened_hash.as_ref()).map_err(|_| WalletError::InvalidSecretKey)
-}
-```
-
-This hardening approach represents what cryptographers call "defense in depth," where multiple independent sources of entropy are combined to create final key material that is resistant to various attack vectors. The function combines the wallet fingerprint, the HD-derived base key, and all three hierarchical levels to create a comprehensive hardening input.
-
-Even if an attacker could somehow predict or influence one or two components of the hardening input, they would still need to compromise the HD key derivation system itself to predict the final keys. The inclusion of all three hierarchical levels in the hardening process ensures that the collision-resistant properties of our derivation system extend through to the final key generation.
-
-Importantly, this hardening function uses only information that is available during both normal operation and disaster recovery scanning, ensuring that recovered keys are mathematically identical to the original keys.
-
-## Step 5: Complete Hierarchical Key Derivation
-
-The complete key derivation function integrates all the hierarchical components into a single deterministic transformation that converts key identifiers into collision-resistant secret keys. This function maintains pure mathematical properties while providing dramatically improved collision resistance.
-
-```rust
-fn derive_secret_key_from_key_id(&self, key_id: [u8; 32]) -> Result<SecretKey> {
-    let derivation_path = self.get_hierarchical_derivation_path(key_id)?;
-    let base_secret_key = self.xprv.derive_priv(&self.secp, &derivation_path)?;
-    let (level_1, level_2, level_3) = self.key_id_to_hierarchical_indices(key_id);
-    let hardened_key = self.apply_hardening_to_base_key(
-        &base_secret_key.private_key,
-        level_1,
-        level_2,
-        level_3,
-    )?;
-    Ok(hardened_key)
-}
-```
-
-This complete derivation function embodies the mathematical elegance of hierarchical deterministic systems. Every component is deterministic and repeatable, yet the combination creates security properties that scale to handle millions of contracts without collision concerns. The function uses the master extended private key (`xprv`) to perform the HD derivation directly, which provides excellent performance and security.
-
-The process flows logically from key identifier to hierarchical derivation path, then to HD-derived base key, and finally to the hardened final key. Each step is reversible during disaster recovery scenarios, ensuring that lost keys can always be systematically rediscovered.
-
-## Complete Contract Signer Implementation
-
-The final integration shows how the hierarchical key derivation integrates with the DLC contract signer interface, providing a clean API that hides the mathematical complexity while delivering collision-resistant key generation.
-
-```rust
-/// Creates a contract signer from a key ID.
-///
-/// Takes the key ID generated by `derive_signer_key_id` and creates a
-/// SimpleSigner that can sign transactions for the specific contract.
-///
-/// # Arguments
-/// * `key_id` - The key ID to derive the signer from
-///
-/// # Returns
-/// A SimpleSigner configured for the contract
-fn derive_contract_signer(
-    &self,
-    key_id: [u8; 32],
-) -> std::result::Result<Self::Signer, ManagerError> {
-    let secret_key = self
-        .derive_secret_key_from_key_id(key_id)
-        .map_err(|e| ManagerError::WalletError(Box::new(e)))?;
-    Ok(SimpleSigner::new(secret_key))
-}
-```
-
-This implementation provides the clean interface that DLC protocols expect while internally performing all the sophisticated hierarchical derivation and hardening operations. The logging provides visibility into the key derivation process for debugging and auditing purposes, while the error handling ensures that any derivation failures are properly propagated and handled.
-
-## Security Analysis: Practical Recovery with Strong Collision Resistance
-
-The implementation presented here strikes an optimal balance between collision resistance and practical disaster recovery capabilities. Understanding this balance is crucial for appreciating why this approach provides both the security needed for large-scale DLC deployments and the recoverability required for long-term operational security.
-
-### Collision Resistance Analysis
-
-With 3,400 slots per level across three levels, our system creates approximately 39.3 billion possible derivation locations. Using birthday paradox mathematics, this provides excellent collision resistance even for millions of contracts. For one million contracts, the probability of experiencing even a single collision is approximately 0.0013%, which represents exceptional collision resistance for practical applications.
-
-Even scaling to ten million contracts, the collision probability remains below 1.3%, providing strong security margins for future growth. This collision resistance is achieved while maintaining a key space that is small enough to be systematically searched during disaster recovery scenarios.
-
-The cryptographic security of this approach leverages Bitcoin's proven HD wallet infrastructure, ensuring that the fundamental security assumptions are well-tested and reliable. The hierarchical derivation uses the same elliptic curve cryptography and hash functions that secure billions of dollars in Bitcoin value.
-
-### Practical Disaster Recovery Capabilities
-
-The constraint to 3,400 slots per level creates a total search space that can be explored within practical time constraints during disaster recovery scenarios. Using modern multi-core systems with optimized parallel processing, the entire 39.3 billion key space can be systematically searched within approximately one week of computation time.
-
-This recovery capability provides a mathematical guarantee that no contract key can be permanently lost as long as you retain access to your wallet's master seed. The systematic scanning process applies the same mathematical transformations used during normal operation, ensuring that recovered keys are identical to the original keys.
-
-The disaster recovery process scales efficiently with available computing resources. Additional CPU cores provide linear improvements in scanning speed, allowing organizations with substantial computing resources to complete recovery operations in days rather than weeks.
-
-### Operational Security Benefits
-
-The hierarchical approach eliminates several operational security risks that plague traditional key management systems. There are no secret keys stored in memory or databases that could be extracted through memory dump attacks or database compromise. Each secret key is computed on-demand and discarded immediately after use.
-
-The deterministic nature of the system means that identical inputs always produce identical outputs, regardless of when or how many times the derivation functions are called. This predictability simplifies testing, auditing, and verification of the key derivation system.
-
-The wallet fingerprint integration ensures that each wallet instance creates its own unique cryptographic namespace, preventing any cross-wallet key reuse attacks even if contract identifiers are reused across different wallet instances.
-
-## Secure Key Identifier Storage for Enhanced Recovery
-
-While the hierarchical deterministic system provides mathematical guarantees for complete key recovery, practical operational security often benefits from additional layers of recovery optimization. A secure storage system for key identifiers can dramatically improve recovery performance while maintaining the deterministic system's dependency-free architecture.
-
-### The Key Identifier Storage Concept
-
-The fundamental insight behind secure key identifier storage is recognizing that key identifiers themselves contain no secret information. They are derived deterministically from contract temporary identifiers and wallet fingerprints, but they do not reveal private keys or enable unauthorized access to contract funds. This property makes them safe to store in auxiliary databases that can accelerate recovery processes without compromising security.
-
-Consider the difference between storing complete secret keys versus storing only the key identifiers that allow secret keys to be derived on demand. Secret key storage creates obvious security vulnerabilities because compromise of the storage system immediately compromises all contract keys. Key identifier storage, by contrast, creates no additional attack surface because the identifiers themselves are not sensitive information.
-
-The key identifier approach transforms the recovery problem from "search the entire mathematical space" to "look up the specific locations we know contain keys." This is like the difference between searching every possible address in a city versus consulting a directory that tells you exactly which addresses contain the buildings you are looking for.
-
-### Implementing Secure Key Identifier Archives
-
-A practical key identifier storage system can be implemented as a simple mapping between contract funding public keys and their corresponding key identifiers. This mapping provides sufficient information to enable instant key recovery without storing any sensitive cryptographic material.
-
-```rust
-/// Secure storage structure for key identifier recovery acceleration
-/// Maps funding public keys to their deterministic key identifiers for fast lookup
-#[derive(Serialize, Deserialize)]
-pub struct KeyIdentifierArchive {
-    /// Version identifier for forward compatibility with storage format changes
-    version: u32,
-    /// Wallet fingerprint to ensure archive matches current wallet
-    wallet_fingerprint: [u8; 4],
-    /// Mapping from funding public keys to their corresponding key identifiers
-    /// Public keys are not sensitive information and safe to store
-    key_mappings: HashMap<PublicKey, [u8; 32]>,
-    /// Optional metadata for operational convenience (contract dates, amounts, etc.)
-    metadata: HashMap<PublicKey, ContractMetadata>,
-}
-
-impl KeyIdentifierArchive {
-    /// Stores a key identifier mapping for future recovery acceleration
-    /// This operation is safe because key identifiers contain no secret information
-    pub fn store_key_mapping(&mut self, funding_pubkey: PublicKey, key_id: [u8; 32], metadata: Option<ContractMetadata>) {
-        self.key_mappings.insert(funding_pubkey, key_id);
-        if let Some(meta) = metadata {
-            self.metadata.insert(funding_pubkey, meta);
-        }
-    }
-
-    /// Retrieves a key identifier for instant secret key derivation
-    /// Eliminates the need for disaster recovery scanning when archive is available
-    pub fn get_key_id(&self, funding_pubkey: &PublicKey) -> Option<[u8; 32]> {
-        self.key_mappings.get(funding_pubkey).copied()
-    }
-}
-```
-
-This storage structure demonstrates how auxiliary systems can enhance deterministic key derivation without creating additional dependencies or security vulnerabilities. The archive contains only public information and key identifiers, both of which are safe to store in various backup locations and security contexts.
-
-The wallet fingerprint verification ensures that archived key identifiers match the current wallet instance, preventing confusion if archives from different wallets are accidentally mixed. The optional metadata provides operational convenience for understanding recovered contracts without affecting the core security properties of the system.
-
-### Tiered Recovery Strategy Implementation
-
-The combination of deterministic derivation and secure key identifier storage creates a sophisticated tiered recovery strategy that gracefully adapts to different disaster scenarios. Each tier provides different recovery capabilities with corresponding time and resource requirements.
-
-```rust
-/// Comprehensive tiered recovery system combining multiple recovery approaches
-/// Automatically selects optimal recovery method based on available information
-pub struct TieredRecoverySystem {
-    dlc_wallet: DlcDevKitWallet,
-    key_archive: Option<KeyIdentifierArchive>,
-}
-
-impl TieredRecoverySystem {
-    /// Tier 1: Instant recovery using archived key identifiers (when available)
-    /// This is the fastest recovery method, completing in microseconds
-    pub fn instant_recovery(&self, funding_pubkey: &PublicKey) -> Result<Option<SecretKey>, WalletError> {
-        if let Some(archive) = &self.key_archive {
-            if let Some(key_id) = archive.get_key_id(funding_pubkey) {
-                let secret_key = self.dlc_wallet.derive_secret_key_from_key_id(key_id)?;
-                return Ok(Some(secret_key));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Tier 2: Reconstruction recovery using contract temporary identifiers
-    /// Used when archives are unavailable but contract data is preserved
-    pub fn reconstruction_recovery(&self, temp_id: [u8; 32]) -> Result<SecretKey, WalletError> {
-        let key_id = self.dlc_wallet.derive_signer_key_id(true, temp_id);
-        self.dlc_wallet.derive_secret_key_from_key_id(key_id)
-    }
-
-    /// Tier 3: Mathematical disaster recovery through systematic keychain scanning
-    /// Used when both archives and contract data are lost, but provides guaranteed recovery
-    pub fn disaster_recovery(&self, target_pubkey: &PublicKey) -> Result<Option<SecretKey>, WalletError> {
-        // Systematic scan through the 39.3 billion possible derivation paths
-        const MAX_LEVEL: u32 = 3400;
-
-        for level_1 in 0..MAX_LEVEL {
-            for level_2 in 0..MAX_LEVEL {
-                for level_3 in 0..MAX_LEVEL {
-                    if let Ok(secret_key) = self.derive_key_at_hierarchical_indices(level_1, level_2, level_3) {
-                        let public_key = PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &secret_key);
-                        if public_key == *target_pubkey {
-                            return Ok(Some(secret_key));
-                        }
-                    }
-                }
-            }
-        }
-        Ok(None)
-    }
-}
-```
-
-This tiered approach provides operational flexibility that adapts to different failure scenarios while maintaining mathematical guarantees for recovery. The instant recovery tier handles normal operational scenarios where archived information is available. The reconstruction tier handles scenarios where contract databases are preserved but key archives are lost. The disaster recovery tier provides mathematical guarantees for complete recovery even when all auxiliary data is lost.
-
-The beauty of this tiered system lies in how each tier degrades gracefully to the next level when needed. Users experience the fastest possible recovery based on available information, but they always retain the mathematical guarantee of complete recoverability through systematic scanning if necessary.
-
-### Security Properties of Key Identifier Storage
-
-The security analysis of key identifier storage reveals why this approach enhances rather than compromises the overall system security. Key identifiers are derived deterministically from non-secret inputs and provide no information that could be used to compromise contract funds or predict other contract keys.
-
-From an information theoretic perspective, key identifiers contain the same information as contract temporary identifiers combined with wallet fingerprints. Since temporary identifiers are typically known to both parties in DLC contracts and fingerprints are not secret, the key identifiers themselves introduce no additional information disclosure.
-
-The storage of key identifiers does create an additional operational component that must be backed up and maintained, but this component contains no secret information and can be stored using conventional database backup practices without special cryptographic protection requirements. The archive can be stored in multiple locations, shared across backup systems, and even transmitted over insecure channels without compromising security.
-
-The threat model for key identifier storage focuses on availability rather than confidentiality. The primary risk is loss of the archive data, which would degrade recovery performance but not compromise security or eliminate recovery capabilities. This represents a much more manageable risk profile than systems that require protecting secret key databases or other sensitive cryptographic materials.
-
-This comprehensive approach to hierarchical deterministic key derivation provides the collision resistance needed for large-scale DLC deployments while maintaining the recoverability properties essential for long-term operational security. The system gracefully balances mathematical perfection with practical usability, creating a foundation for DLC implementations that can scale to millions of contracts while providing robust disaster recovery capabilities and operational flexibility through secure auxiliary storage systems.
+`sk` is the funding secret key. Its public key is published in the offer or
+accept message as `funding_pubkey`.
+
+### Step 1: keys id
+
+The `keys_id` is the value the manager stores with each contract. It contains no
+secret. The fingerprint makes the id different in each wallet for the same
+`temp_id`. The tag names the scheme version.
+
+**The `keys_id` carries its scheme.** A V1 id ends with the 8-byte marker
+`DDKKEYv1` in bytes `24..32`, which the derivation never reads. Any id without
+the marker is a V0 id. `KeyScheme::of_keys_id` makes this decision, and
+`funding_secret_key_for_keys_id` (used by `derive_contract_signer`) derives with
+the scheme it finds. This is what keeps stored contracts working after an
+upgrade: the manager feeds the stored id back in and gets the key that funded
+the contract. A V0 id is a full SHA-256 output, so the chance that it ends with
+the marker by accident is 2^-64.
+
+`ContractSignerProvider::derive_signer_key_id(temp_id)` returns the V1 id. It
+takes only the temporary id. Both parties of a contract call it with the same
+`temp_id` and get unrelated keys, because their fingerprints and master keys
+differ.
+
+### Step 2: three hardened levels
+
+The first 12 bytes of the `keys_id` give three child indices in the range
+`0..3400`. The three levels give `3400^3`, about 39.3 billion, distinct paths.
+For one million contracts the probability of two contracts on the same path is
+about 0.0013 %. Two contracts on the same path get the same funding key, so a
+path collision is a key collision. The space is large enough that this does not
+occur in practice and small enough that a full scan is possible (see
+[Disaster recovery](#disaster-recovery)).
+
+In V1, **every level of the path is hardened**, including the three contract
+levels. This is the security boundary of the scheme:
+
+- A leaked contract key together with any extended public key of the tree does
+  not give the parent private key. Non-hardened BIP32 derivation would allow
+  this walk-up; hardened derivation does not.
+- No extended public key can derive contract public keys. Watch-only derivation
+  of funding keys was never possible in V0 either, because of the final hash, so
+  hardening the levels removes no function.
+
+The rule for operators is the standard BIP32 rule: protect the master `xprv`.
+There are no additional invariants.
+
+V0 contract levels are not hardened. The V0 code path exists only to derive the
+keys of contracts that were funded under V0. New contracts never use it.
+
+**Explicit V0 use is rejected at compile time.** `KeyScheme::V0` carries
+`#[deprecated]`. Naming it is a deprecation diagnostic for downstream crates,
+and the `ddk` and `ddk-manager` crates deny that lint, so inside the library it
+is a hard error. The only code allowed to name V0 is the scheme dispatch in
+`keys.rs` and its tests. Everything else reaches V0 through the resolvers that
+read the scheme from stored data: `funding_secret_key_for_keys_id` (marker) and
+`funding_secret_key_for_pubkey` (published pubkey). The manager never names a
+scheme at all: it calls `derive_signer_key_id`, which is always V1, and
+`derive_contract_signer`, which follows the stored id.
+
+### Step 3: domain-tagged hash
+
+The final SHA-256 over the hardened child is defense in depth. It is not
+load-bearing. An attacker who obtains a dump of the `m/420'/0'/0'` subtree still
+needs one SHA-256 preimage per contract. The V1 tag `CONTRACT_KEY_V1` names the
+construction. The wallet fingerprint is not part of the V1 hash: it is public and
+adds nothing. V0 used the fingerprint in this position.
+
+The intermediate `base_sk` is a real secret of the wallet's key tree. The code
+wipes it, and the hash input buffer that contains it, as soon as `sk` exists.
+
+## API
+
+| Need | Call |
+|---|---|
+| Key id for a new contract | `keys_id(temp_id)` |
+| Key id under a given scheme | `keys_id_with_scheme(temp_id, scheme)` |
+| Key from a stored key id (any scheme) | `funding_secret_key_for_keys_id(keys_id)` |
+| Key for a new contract | `funding_secret_key(temp_id)` / `funding_pubkey(temp_id)` |
+| Key under a given scheme | `funding_secret_key_with_scheme(temp_id, scheme)` |
+| Key of an existing contract from its messages | `funding_secret_key_for_pubkey(temp_id, &funding_pubkey)` |
+| Splice key for a prior contract | `dlc_input_signing_key(prior_temp_id, &prior_funding_pubkey, serial_id)` |
+| Which scheme made a key id | `KeyScheme::of_keys_id(&keys_id)` |
+
+`funding_secret_key_for_pubkey` and `dlc_input_signing_key` try every scheme,
+newest first, and return the key whose public key matches. They fail if no
+scheme matches. The stateless API keeps only wire messages, and the messages do
+not say which scheme was current when the contract was made, so the published
+funding pubkey is the selector. A splice of a V0 contract therefore works with
+the prior offer or accept message alone.
+
+## Disaster recovery
+
+Recovery has three tiers. Each tier uses the same derivation as normal
+operation, so recovered keys are identical to the original keys.
+
+1. **Stored contract.** The manager stores the `keys_id` with each contract.
+   `derive_contract_signer(keys_id)` returns the key directly, for V0 and V1
+   ids alike.
+2. **Known temporary id and funding pubkey.** Given the `OfferDlc` and
+   `AcceptDlc`, `funding_secret_key_for_pubkey(temp_id, &funding_pubkey)`
+   returns the key under whichever scheme made it.
+3. **Full scan.** Given only the seed and a target `funding_pubkey`, iterate
+   `l1, l2, l3` over `0..3400` each, derive `base_sk`, apply the final hash with
+   those indices, and compare the public key. Run the scan once per scheme:
+   V1 with hardened levels and the V1 tag, then V0 with normal levels and the
+   fingerprint. Each scan covers 39.3 billion paths and completes in about one
+   week on a modern multi-core machine. It scales linearly with cores.
+
+## Migration from V0
+
+V1 changed three things: the keys-id tag and marker, hardened contract levels,
+and the domain tag in place of the fingerprint in the final hash. A V1 provider
+never reproduces a V0 key from a V1 id, and the two schemes never collide, so
+every key belongs to exactly one scheme.
+
+Nothing needs to be done at upgrade time:
+
+- Contracts **funded before** the upgrade to `2.0.0-rc.3` have V0 ids in
+  storage and keep deriving on **V0**.
+- Contracts **offered or accepted after** the upgrade get V1 ids and derive on
+  **V1**.
+- Splices from a V0 contract into a new V1 contract work through
+  `dlc_input_signing_key`, which selects V0 from the prior funding pubkey.
+
+Tests in `keys.rs` pin this behaviour: `v0_reference_matches_the_shipped_v0_vectors`
+pins the exact `2.0.0-rc.2` output for a fixed mnemonic against an independent
+re-implementation, `a_stored_v0_keys_id_derives_the_v0_key` covers the manager
+path, and `v1_keys_differ_from_v0_keys_for_the_same_temp_id` pins the boundary.
+
+## Test vectors
+
+Mnemonic `abandon abandon abandon abandon abandon abandon abandon abandon abandon
+abandon abandon about`, no passphrase, regtest, `temp_id = 0xA1 * 32`:
+
+| Scheme | `keys_id` | `funding_pubkey` |
+|---|---|---|
+| V0 | `a7649d1c927f2b8af024e9a1d3b59c84da975629a2c3805f16afa19090ab6115` | `03aa70703dca189d6df5cc73408d2e96f4c3f3a761f4889653984b8a694956a35a` |
+| V1 | `5604be211579c6a4c28fa5e61ce059ae4f4716c2bee2da0f44444b4b45597631` | `03c952c4c3a4f7b69ab23bbc8d1d6f1a1487beca22edeb32c3116f82ac8aca7159` |
+
+The V1 id ends in `44444b4b45597631`, the ASCII bytes of `DDKKEYv1`.


### PR DESCRIPTION
## Summary
Contract funding keys now derive on a fully hardened BIP32 path with a domain-tagged final hash (scheme V1), which closes the walk-up attack from the red team audit (C1: a leaked contract key plus an ancestor xpub recovered the parent key). Contracts funded by earlier releases keep working: their stored `keys_id` has no V1 marker and derives on the V0 scheme as before.

## Changes
- **V1 derivation.** Path is `m/420'/0'/0'/l1'/l2'/l3'` (all levels hardened). The final hash is `SHA256("CONTRACT_KEY_V1" || base_sk || l1 || l2 || l3)`; the public wallet fingerprint is dropped from it. The intermediate BIP32 child key and the hash buffer are zeroized after use (`zeroize` added to `ddk`).
- **Scheme carried in the `keys_id`.** V1 ids end with the 8-byte marker `DDKKEYv1` in bytes the derivation never reads. `funding_secret_key_for_keys_id` (and so `derive_contract_signer`) reads the marker and derives on V0 or V1. A V0 id is a full SHA-256 output, so a false match is 2^-64.
- **V0 is unlock-only.** `KeyScheme::V0` is `#[deprecated]`, and `ddk` and `ddk-manager` deny that lint, so naming V0 is a hard error inside the library and a warning downstream. Only the scheme dispatch in `keys.rs` and its tests may name it.
- **Splice from an old contract.** `dlc_input_signing_key` now takes the prior funding pubkey from the prior offer or accept message and resolves the scheme from it (V1 first, then V0). It errors if neither matches instead of returning a wrong key. `funding_secret_key_for_pubkey` exposes the same resolver for recovery tooling.
- **Trait cleanup.** `ContractSignerProvider::derive_signer_key_id` drops the unused `is_offer_party` flag. The id was never a function of it.
- **Docs.** `docs/contract-key-derivation.md` is rewritten for both schemes: layout of the id, the compile-time guard, the API table, the three recovery tiers, and test vectors.

Breaking: `derive_signer_key_id` and `dlc_input_signing_key` signatures. Funding keys for new contracts change. No migration step for existing contracts.

## Testing
- New tests pin the V0 scheme against vectors captured from the `2.0.0-rc.2` code before the change, using an independent re-implementation, and check that a stored V0 `keys_id` still derives the V0 key through the signer trait. V1 vectors are pinned too, and the two schemes are asserted never to collide.
- Probed the guard: naming `KeyScheme::V0` inside `ddk` fails to compile; in a downstream example it warns.
- `cargo test -p ddk --lib`, `cargo test -p ddk-manager`, `cargo test -p ddk --test stateless`, and the full `stateless_execution` splice matrix on regtest (including accept-party and alternating-party splice chains, and the mnemonic recovery splice) pass. `cargo clippy --workspace --all-targets --examples` is clean on touched files.
