### PR TITLE
manager: bind oracle attestations to the adaptor index set

### DIFF
--- a/ddk-manager/src/contract/contract_info.rs
+++ b/ddk-manager/src/contract/contract_info.rs
@@ -8,12 +8,18 @@ use bitcoin::Amount;
 use bitcoin::{Script, Transaction};
 use ddk_dlc::{OracleInfo, Payout};
 use ddk_messages::oracle_msgs;
-use ddk_messages::oracle_msgs::{EventDescriptor, OracleAnnouncement};
+use ddk_messages::oracle_msgs::{EventDescriptor, OracleAnnouncement, OracleAttestation};
 use ddk_trie::{DlcTrie, RangeInfo};
+use secp256k1_zkp::schnorr::Signature as SchnorrSignature;
 use secp256k1_zkp::{All, EcdsaAdaptorSignature, PublicKey, Secp256k1, SecretKey, Verification};
 use std::ops::Deref;
 
 pub(super) type OracleIndexAndPrefixLength = Vec<(usize, usize)>;
+
+/// The CET and adaptor signature indexes for an attested outcome, with the
+/// oracle signatures that decrypt the adaptor signature: one set per oracle of
+/// the matched combination.
+pub type RangeInfoAndOracleSignatures = (RangeInfo, Vec<Vec<SchnorrSignature>>);
 
 /// Contains information about the contract conditions and oracles used.
 #[derive(Clone, Debug)]
@@ -184,6 +190,39 @@ impl ContractInfo {
         }
     }
 
+    /// Finds the CET matching the attested outcomes and selects the oracle
+    /// signatures that decrypt its adaptor signature.
+    ///
+    /// The adaptor secret is the sum of one signature set per oracle of the
+    /// combination the adaptor point was built for, so the attestations must
+    /// bind to that index set: every oracle index must be distinct, and every
+    /// oracle of the matched combination must have an attestation with at least
+    /// as many signatures as the matched outcome prefix. Attestations from
+    /// oracles outside the matched combination are not used, so a
+    /// `threshold`-of-`n` contract accepts up to `n` attestations.
+    ///
+    /// Returns `Ok(None)` when no outcome of this contract info matches the
+    /// attestations.
+    pub fn get_range_info_and_oracle_signatures(
+        &self,
+        adaptor_info: &AdaptorInfo,
+        attestations: &[(usize, OracleAttestation)],
+        adaptor_sig_start: usize,
+    ) -> Result<Option<RangeInfoAndOracleSignatures>, Error> {
+        ensure_distinct_oracle_indices(attestations)?;
+        let outcomes: Vec<(usize, &Vec<String>)> = attestations
+            .iter()
+            .map(|(index, attestation)| (*index, &attestation.outcomes))
+            .collect();
+        let Some((signature_infos, range_info)) =
+            self.get_range_info_for_outcome(adaptor_info, &outcomes, adaptor_sig_start)
+        else {
+            return Ok(None);
+        };
+        let signatures = select_oracle_signatures(&signature_infos, attestations)?;
+        Ok(Some((range_info, signatures)))
+    }
+
     /// Verifies the given adaptor signatures are valid with respect to the given
     /// adaptor info.
     #[allow(clippy::too_many_arguments)]
@@ -328,9 +367,193 @@ fn get_digits_outcome(input: &[String]) -> Result<Vec<usize>, crate::error::Erro
         .collect::<Result<Vec<usize>, crate::error::Error>>()
 }
 
+/// Checks that no oracle index appears more than once in `attestations`.
+///
+/// A repeated oracle would count twice towards the threshold and its
+/// signatures would be summed twice into the adaptor secret.
+pub fn ensure_distinct_oracle_indices(
+    attestations: &[(usize, OracleAttestation)],
+) -> Result<(), Error> {
+    let mut indices: Vec<usize> = attestations.iter().map(|(index, _)| *index).collect();
+    indices.sort_unstable();
+    match indices.windows(2).find(|pair| pair[0] == pair[1]) {
+        Some(pair) => Err(Error::InvalidParameters(format!(
+            "Oracle {} has more than one attestation",
+            pair[0]
+        ))),
+        None => Ok(()),
+    }
+}
+
+/// Selects, for each `(oracle index, prefix length)` pair of a matched outcome,
+/// the first `prefix length` signatures of that oracle's attestation.
+///
+/// Each oracle in `signature_infos` must have exactly one attestation carrying
+/// at least `prefix length` signatures. A missing oracle or a short attestation
+/// is an error, not a silently shorter signature set.
+pub fn select_oracle_signatures(
+    signature_infos: &[(usize, usize)],
+    attestations: &[(usize, OracleAttestation)],
+) -> Result<Vec<Vec<SchnorrSignature>>, Error> {
+    ensure_distinct_oracle_indices(attestations)?;
+    signature_infos
+        .iter()
+        .map(|(oracle_index, prefix_length)| {
+            let (_, attestation) = attestations
+                .iter()
+                .find(|(index, _)| index == oracle_index)
+                .ok_or_else(|| {
+                    Error::InvalidParameters(format!(
+                        "No attestation for oracle {oracle_index}, which the matched outcome requires"
+                    ))
+                })?;
+            if attestation.signatures.len() < *prefix_length {
+                return Err(Error::InvalidParameters(format!(
+                    "Attestation from oracle {oracle_index} has {} signatures but the matched outcome needs {prefix_length}",
+                    attestation.signatures.len()
+                )));
+            }
+            Ok(attestation.signatures[..*prefix_length].to_vec())
+        })
+        .collect()
+}
+
 fn outcomes_to_digits(outcomes: &[(usize, &Vec<String>)]) -> Vec<(usize, Vec<usize>)> {
     outcomes
         .iter()
         .filter_map(|(x, path)| Some((*x, get_digits_outcome(path).ok()?)))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::enum_descriptor::EnumDescriptor;
+    use ddk_dlc::{EnumerationPayout, Payout};
+    use ddk_messages::oracle_msgs::{EnumEventDescriptor, OracleEvent};
+    use secp256k1_zkp::XOnlyPublicKey;
+    use std::str::FromStr;
+
+    const NB_ORACLES: usize = 3;
+    const THRESHOLD: usize = 2;
+
+    fn oracle_public_key() -> XOnlyPublicKey {
+        XOnlyPublicKey::from_str("e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443")
+            .unwrap()
+    }
+
+    fn signature() -> SchnorrSignature {
+        SchnorrSignature::from_str("6470FD1303DDA4FDA717B9837153C24A6EAB377183FC438F939E0ED2B620E9EE5077C4A8B8DCA28963D772A94F5F0DDF598E1C47C137F91933274C7C3EDADCE8").unwrap()
+    }
+
+    /// An enum contract on `NB_ORACLES` oracles with a `THRESHOLD`. The
+    /// signature selection never verifies signatures, so placeholder keys and
+    /// signatures are enough.
+    fn enum_contract_info() -> ContractInfo {
+        let oracle_announcements = (0..NB_ORACLES)
+            .map(|_| OracleAnnouncement {
+                announcement_signature: signature(),
+                oracle_public_key: oracle_public_key(),
+                oracle_event: OracleEvent {
+                    oracle_nonces: vec![oracle_public_key()],
+                    event_maturity_epoch: 0,
+                    event_descriptor: EventDescriptor::EnumEvent(EnumEventDescriptor {
+                        outcomes: vec!["a".to_string(), "b".to_string()],
+                    }),
+                    event_id: "test".to_string(),
+                },
+            })
+            .collect();
+        ContractInfo {
+            contract_descriptor: ContractDescriptor::Enum(EnumDescriptor {
+                outcome_payouts: vec![
+                    EnumerationPayout {
+                        outcome: "a".to_string(),
+                        payout: Payout {
+                            offer: Amount::from_sat(100),
+                            accept: Amount::ZERO,
+                        },
+                    },
+                    EnumerationPayout {
+                        outcome: "b".to_string(),
+                        payout: Payout {
+                            offer: Amount::ZERO,
+                            accept: Amount::from_sat(100),
+                        },
+                    },
+                ],
+            }),
+            oracle_announcements,
+            threshold: THRESHOLD,
+        }
+    }
+
+    fn attestation(outcome: &str) -> OracleAttestation {
+        OracleAttestation {
+            event_id: "test".to_string(),
+            oracle_public_key: oracle_public_key(),
+            signatures: vec![signature()],
+            outcomes: vec![outcome.to_string()],
+        }
+    }
+
+    fn lookup(
+        attestations: &[(usize, OracleAttestation)],
+    ) -> Result<Option<RangeInfoAndOracleSignatures>, Error> {
+        enum_contract_info().get_range_info_and_oracle_signatures(
+            &AdaptorInfo::Enum,
+            attestations,
+            0,
+        )
+    }
+
+    #[test]
+    fn exact_threshold_attestations_select_one_signature_set_per_oracle() {
+        let (range_info, signatures) = lookup(&[(1, attestation("a")), (2, attestation("a"))])
+            .unwrap()
+            .expect("outcome a has a CET");
+        assert_eq!(range_info.cet_index, 0);
+        assert_eq!(signatures.len(), THRESHOLD);
+        assert!(signatures.iter().all(|set| set.len() == 1));
+    }
+
+    #[test]
+    fn attestations_beyond_the_threshold_are_not_summed_into_the_secret() {
+        let (_, signatures) = lookup(&[
+            (0, attestation("a")),
+            (1, attestation("a")),
+            (2, attestation("a")),
+        ])
+        .unwrap()
+        .expect("outcome a has a CET");
+        assert_eq!(signatures.len(), THRESHOLD);
+    }
+
+    #[test]
+    fn a_duplicated_oracle_index_is_rejected() {
+        let error = lookup(&[(0, attestation("a")), (0, attestation("a"))]).unwrap_err();
+        assert!(matches!(error, Error::InvalidParameters(_)), "{error}");
+    }
+
+    #[test]
+    fn an_attestation_with_too_few_signatures_is_rejected() {
+        let mut unsigned = attestation("a");
+        unsigned.signatures.clear();
+        let error = lookup(&[(0, unsigned), (1, attestation("a"))]).unwrap_err();
+        assert!(matches!(error, Error::InvalidParameters(_)), "{error}");
+    }
+
+    #[test]
+    fn an_unknown_outcome_has_no_range_info() {
+        assert!(lookup(&[(0, attestation("c")), (1, attestation("c"))])
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn a_missing_oracle_in_the_matched_combination_is_rejected() {
+        let error =
+            select_oracle_signatures(&[(0, 1), (1, 1)], &[(0, attestation("a"))]).unwrap_err();
+        assert!(matches!(error, Error::InvalidParameters(_)), "{error}");
+    }
 }

--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -1054,7 +1054,9 @@ where
             .iter()
             .map(|(_, a)| &a.outcomes)
             .collect::<Vec<_>>(),
-        attestations.first().unwrap().1.event_id,
+        attestations
+            .first()
+            .map_or("", |(_, attestation)| attestation.event_id.as_str()),
     );
     let (range_info, sigs) =
         crate::utils::get_range_info_and_oracle_sigs(contract_info, adaptor_info, attestations)?;

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -1245,17 +1245,18 @@ where
         let contract_infos = &contract.accepted_contract.offered_contract.contract_info;
         let adaptor_infos = &contract.accepted_contract.adaptor_infos;
 
-        // find the contract info that matches the attestations
+        // Find the contract info whose oracles produced every attestation.
+        // Each attestation must be a valid signature from the oracle at the
+        // index it claims, so a forged, misindexed, or out-of-range attestation
+        // disqualifies the whole set instead of being skipped.
         if let Some((contract_info, adaptor_info)) =
             contract_infos.iter().zip(adaptor_infos).find(|(c, _)| {
-                let matches = attestations
-                    .iter()
-                    .filter(|(i, a)| {
-                        c.oracle_announcements[*i].oracle_event.oracle_nonces == a.nonces()
+                attestations.len() >= c.threshold
+                    && attestations.iter().all(|(i, a)| {
+                        c.oracle_announcements.get(*i).is_some_and(|announcement| {
+                            a.validate(&self.secp, announcement).is_ok()
+                        })
                     })
-                    .count();
-
-                matches >= c.threshold
             })
         {
             let offer = &contract.accepted_contract.offered_contract;

--- a/ddk-manager/src/utils.rs
+++ b/ddk-manager/src/utils.rs
@@ -242,30 +242,22 @@ pub(crate) fn get_half_common_fee(fee_rate: u64) -> Result<Amount, Error> {
     Ok(common_fee / 2)
 }
 
+/// Finds the CET for the attested outcomes and the oracle signatures that
+/// decrypt its adaptor signature.
+///
+/// Attestations must bind one to one to the oracles of the matched
+/// combination; see
+/// [`ContractInfo::get_range_info_and_oracle_signatures`].
 pub(crate) fn get_range_info_and_oracle_sigs(
     contract_info: &ContractInfo,
     adaptor_info: &AdaptorInfo,
     attestations: &[(usize, OracleAttestation)],
 ) -> Result<(RangeInfo, Vec<Vec<secp256k1_zkp::schnorr::Signature>>), Error> {
-    let outcomes = attestations
-        .iter()
-        .map(|(i, x)| (*i, &x.outcomes))
-        .collect::<Vec<(usize, &Vec<String>)>>();
-    let info_opt = contract_info.get_range_info_for_outcome(adaptor_info, &outcomes, 0);
-    if let Some((sig_infos, range_info)) = info_opt {
-        let sigs: Vec<Vec<_>> = attestations
-            .iter()
-            .filter_map(|(i, a)| {
-                let sig_info = sig_infos.iter().find(|x| x.0 == *i)?;
-                Some(a.signatures.iter().take(sig_info.1).cloned().collect())
-            })
-            .collect();
-        return Ok((range_info, sigs));
-    }
-
-    Err(Error::InvalidState(
-        "Could not find closing info for given outcomes".to_string(),
-    ))
+    contract_info
+        .get_range_info_and_oracle_signatures(adaptor_info, attestations, 0)?
+        .ok_or_else(|| {
+            Error::InvalidState("Could not find closing info for given outcomes".to_string())
+        })
 }
 
 pub(crate) fn get_latest_maturity_date(

--- a/ddk-manager/tests/manager_execution_tests.rs
+++ b/ddk-manager/tests/manager_execution_tests.rs
@@ -1592,6 +1592,7 @@ async fn close_path(
         periodic_check!(ctx.manager(first), contract_id, Confirmed);
 
         let attestations = get_attestations(test_params).await;
+        assert_manual_close_rejects_bad_attestations(ctx, first, contract_id, &attestations).await;
 
         let contract = ctx
             .manager(first)
@@ -1640,6 +1641,40 @@ async fn close_path(
         periodic_check!(ctx.manager(first), contract_id, PreClosed);
         periodic_check!(ctx.manager(second), contract_id, PreClosed);
     }
+}
+
+/// A manual close must refuse attestation sets that do not bind one to one to
+/// the contract's oracles, and must leave the contract confirmed when it does.
+async fn assert_manual_close_rejects_bad_attestations(
+    ctx: &TestContext,
+    party: Party,
+    contract_id: ContractId,
+    attestations: &[(usize, OracleAttestation)],
+) {
+    let (index, attestation) = attestations[0].clone();
+
+    // The same oracle twice: its signatures would be summed twice into the
+    // adaptor secret.
+    let mut duplicated = attestations.to_vec();
+    duplicated.push((index, attestation.clone()));
+    ctx.manager(party)
+        .lock()
+        .await
+        .close_confirmed_contract(&contract_id, duplicated)
+        .await
+        .expect_err("a duplicated oracle attestation must not close the contract");
+
+    // An index no contract in these tests has an oracle at.
+    let mut out_of_range = attestations.to_vec();
+    out_of_range.push((99, attestation));
+    ctx.manager(party)
+        .lock()
+        .await
+        .close_confirmed_contract(&contract_id, out_of_range)
+        .await
+        .expect_err("an attestation for an unknown oracle must not close the contract");
+
+    assert_contract_state!(ctx.manager(party), contract_id, Confirmed);
 }
 
 /// Runs a confirmed contract past its refund locktime, either letting the

--- a/ddk/src/contract/settle.rs
+++ b/ddk/src/contract/settle.rs
@@ -40,6 +40,9 @@ use super::types::Party;
 /// announcements of the contract info it settles. For a contract with several
 /// disjoint contract infos, the first one whose outcome the attestations
 /// resolve is used, so it is enough to pass the attestations for one event.
+/// Each oracle may appear at most once: the adaptor secret is the sum of one
+/// signature set per oracle, so a repeated index is rejected with
+/// [`ContractError::InvalidAttestation`] instead of being summed twice.
 ///
 /// Returns [`ContractError::NoMatchingOutcome`] when no contract outcome
 /// corresponds to the attested outcomes, which is also what an attestation for
@@ -61,10 +64,6 @@ pub fn sign_cet(
     let total_collateral = offer.get_total_collateral();
     let funding_witness_script = &context.transactions.funding_witness_script;
     let fund_value = context.transactions.get_fund_output().value;
-    let outcomes: Vec<(usize, &Vec<String>)> = attestations
-        .iter()
-        .map(|(index, attestation)| (*index, &attestation.outcomes))
-        .collect();
 
     let mut signature_index = 0;
     for (info, cet_range) in context.execution_infos.iter().zip(&context.cet_ranges) {
@@ -85,8 +84,12 @@ pub fn sign_cet(
                 counterparty_error(party)(format!("invalid CET adaptor signatures: {e}"))
             })?;
 
-        let Some((signature_infos, range_info)) =
-            info.get_range_info_for_outcome(&adaptor_info, &outcomes, signature_index)
+        // The lookup also binds the attestations to the oracle combination the
+        // adaptor point was built for: one attestation per oracle, and a
+        // signature set for every oracle of the matched combination.
+        let Some((range_info, oracle_signatures)) = info
+            .get_range_info_and_oracle_signatures(&adaptor_info, attestations, signature_index)
+            .map_err(attestation_error)?
         else {
             signature_index = next_index;
             continue;
@@ -97,20 +100,6 @@ pub fn sign_cet(
         // `cet_index` is relative to the CETs of this contract info; the
         // adaptor index already carries the running offset.
         let mut cet = context.transactions.cets[cet_range.start + range_info.cet_index].clone();
-        let oracle_signatures: Vec<Vec<_>> = attestations
-            .iter()
-            .filter_map(|(index, attestation)| {
-                let signature_info = signature_infos.iter().find(|info| info.0 == *index)?;
-                Some(
-                    attestation
-                        .signatures
-                        .iter()
-                        .take(signature_info.1)
-                        .cloned()
-                        .collect(),
-                )
-            })
-            .collect();
 
         ddk_dlc::sign_cet(
             &secp,
@@ -222,6 +211,16 @@ fn counterparty_error(party: Party) -> fn(String) -> ContractError {
     match party {
         Party::Offer => ContractError::InvalidAccept,
         Party::Accept => ContractError::InvalidSign,
+    }
+}
+
+/// Reports an attestation set that does not bind to the contract's oracles.
+fn attestation_error(error: ddk_manager::error::Error) -> ContractError {
+    match error {
+        ddk_manager::error::Error::InvalidParameters(message) => {
+            ContractError::InvalidAttestation(message)
+        }
+        other => ContractError::InvalidAttestation(other.to_string()),
     }
 }
 

--- a/ddk/tests/stateless.rs
+++ b/ddk/tests/stateless.rs
@@ -1276,6 +1276,30 @@ fn an_out_of_range_oracle_index_is_rejected() {
 }
 
 #[test]
+fn a_duplicated_oracle_attestation_is_rejected() {
+    let secp = Secp256k1::new();
+    let (offerer, accepter, offer, accept) = enum_contract(&secp, NETWORK);
+    let (sign, _) = fund_with_xpriv(&secp, &offerer, &accepter, &offer, &accept);
+
+    // The same genuine attestation twice. Without the index check its
+    // signature would be summed twice into the adaptor secret and the CET would
+    // carry an invalid counterparty signature.
+    let attestation = oracle_attestation(vec!["up".to_string()]);
+    let error = sign_cet(
+        &offer,
+        &accept,
+        &sign,
+        &offerer.funding_secret_key,
+        &[(0, attestation.clone()), (0, attestation)],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(error, ContractError::InvalidAttestation(_)),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn settling_with_a_mismatched_sign_message_is_rejected() {
     let secp = Secp256k1::new();
     let (offerer, accepter, offer, accept) = enum_contract(&secp, NETWORK);

--- a/dlc/src/lib.rs
+++ b/dlc/src/lib.rs
@@ -974,23 +974,28 @@ pub fn create_cet_adaptor_sigs_from_oracle_info(
         .collect()
 }
 
+/// Sums the `s` values of the given oracle signatures into the secret that
+/// decrypts a CET adaptor signature.
+///
+/// Every `s` value must be a valid non-zero scalar and so must the running
+/// sum. A malformed signature is reported as an error, never unwrapped, since
+/// attestations can come from outside the process.
 fn signatures_to_secret(signatures: &[Vec<SchnorrSignature>]) -> Result<SecretKey, Error> {
     let s_values = signatures
         .iter()
         .flatten()
-        .map(|x| match secp_utils::schnorrsig_decompose(x) {
-            Ok(v) => Ok(v.1),
-            Err(err) => Err(err),
-        })
+        .map(|x| secp_utils::schnorrsig_decompose(x).map(|(_, s)| s))
         .collect::<Result<Vec<&[u8]>, Error>>()?;
-    let secret = SecretKey::from_slice(s_values[0])?;
+    let (first, rest) = s_values.split_first().ok_or_else(|| {
+        Error::InvalidArgument("No oracle signatures to build the adaptor secret from".to_string())
+    })?;
+    let secret = SecretKey::from_slice(first)?;
 
-    let result = s_values.iter().skip(1).fold(secret, |accum, s| {
-        let sec = SecretKey::from_slice(s).unwrap();
-        accum.add_tweak(&Scalar::from(sec)).unwrap()
-    });
-
-    Ok(result)
+    rest.iter()
+        .try_fold(secret, |accum, s| -> Result<SecretKey, Error> {
+            let sec = SecretKey::from_slice(s)?;
+            Ok(accum.add_tweak(&Scalar::from(sec))?)
+        })
 }
 
 /// Sign the given cet using own private key, adapt the counter party signature
@@ -1097,6 +1102,36 @@ mod tests {
     use std::fmt::Write;
     use std::str::FromStr;
     use util;
+
+    #[test]
+    fn signatures_to_secret_rejects_an_empty_signature_set() {
+        assert!(matches!(
+            signatures_to_secret(&[]),
+            Err(Error::InvalidArgument(_))
+        ));
+        assert!(matches!(
+            signatures_to_secret(&[Vec::new()]),
+            Err(Error::InvalidArgument(_))
+        ));
+    }
+
+    #[test]
+    fn signatures_to_secret_rejects_a_zero_s_value() {
+        let secp = Secp256k1::new();
+        let keypair = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[7; 32]).unwrap());
+        let valid = secp.sign_schnorr_no_aux_rand(&Message::from_digest([1; 32]), &keypair);
+
+        // A well-formed 64-byte signature whose `s` is zero cannot be a secret
+        // key. It must be reported wherever it sits in the signature set.
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&keypair.x_only_public_key().0.serialize());
+        let zero_s = SchnorrSignature::from_slice(&bytes).unwrap();
+
+        assert!(signatures_to_secret(&[vec![zero_s]]).is_err());
+        assert!(signatures_to_secret(&[vec![valid], vec![zero_s]]).is_err());
+        assert!(signatures_to_secret(&[vec![valid, zero_s]]).is_err());
+        assert!(signatures_to_secret(&[vec![valid], vec![valid]]).is_ok());
+    }
 
     fn create_txin_vec(sequence: Sequence) -> Vec<TxIn> {
         let mut inputs = Vec::new();


### PR DESCRIPTION
## Summary
Binds oracle attestations to the oracle combination a CET adaptor point was built for, so a duplicated, missing, or short attestation set can no longer produce a wrong adaptor secret or a panic. Fixes finding H2 of the red team audit.

## Changes
- Add `ContractInfo::get_range_info_and_oracle_signatures`: rejects duplicate oracle indices before the outcome lookup, then requires one attestation with enough signatures for every oracle of the matched combination. Attestations from oracles outside the combination are ignored instead of summed into the secret, so `t`-of-`n` contracts still close when all `n` oracles attest.
- Route the manager close path, the channel close path, and the stateless `sign_cet` through the shared check.
- `close_confirmed_contract` validates every attestation against the announcement at its index and uses a bounds-checked lookup. Before, an out-of-range index panicked and an invalid attestation was skipped instead of rejected.
- `signatures_to_secret` returns errors for an empty set and for zero or out-of-range `s` values instead of unwrapping.
- `get_signed_cet` no longer unwraps the first attestation for its log line.

## Testing
- New unit tests on the shared lookup (exact threshold, extra attestations, duplicate index, short attestation, unknown outcome, missing oracle) and on `signatures_to_secret`.
- New stateless test: a duplicated attestation is rejected.
- Manual-close regtest paths now first submit a duplicated and an out-of-range attestation set and assert the contract stays confirmed.
- Ran `cargo test -p ddk-dlc --lib`, `cargo test -p ddk-manager --lib`, `cargo test -p ddk --test stateless`, and the ignored regtest suites for manual/automatic enum, numeric, and disjoint closes in `manager_execution_tests` and `stateless_execution`. All pass.
