### PR TITLE
manager: pay cooperative close fees, gate counterparty closes, pin cet_locktime

### DIFF
--- a/ddk-manager/src/channel_updater.rs
+++ b/ddk-manager/src/channel_updater.rs
@@ -83,7 +83,7 @@ pub async fn offer_channel<C: Signing, W: Deref, SP: Deref, B: Deref, T: Deref, 
     wallet: &W,
     signer_provider: &SP,
     blockchain: &B,
-    time: &T,
+    _time: &T,
     temporary_channel_id: ChannelId,
 ) -> Result<(OfferedChannel, OfferedContract), Error>
 where
@@ -117,7 +117,6 @@ where
         &funding_inputs_info,
         counter_party,
         refund_delay,
-        time.unix_time_now() as u32,
         keys_id,
         crate::contract::chain_hash_from_network(blockchain.get_network()?),
     );
@@ -1168,7 +1167,6 @@ where
         &[],
         &signed_channel.counter_party,
         refund_delay,
-        time.unix_time_now() as u32,
         keys_id,
         chain_hash,
     );
@@ -1882,8 +1880,9 @@ where
             vout: signed_channel.fund_output_index as u32,
         },
         fund_output_value,
+        signed_channel.fee_rate_per_vb,
         &additional_inputs,
-    );
+    )?;
 
     let keys_id = signed_channel
         .keys_id()
@@ -1958,8 +1957,9 @@ where
             vout: signed_channel.fund_output_index as u32,
         },
         fund_output_value,
+        signed_channel.fee_rate_per_vb,
         &[], // TODO: Add additional inputs parameter to prevent free option problem
-    );
+    )?;
 
     let mut state = SignedChannelState::CollaborativeCloseOffered {
         counter_payout: close_offer.counter_payout,

--- a/ddk-manager/src/contract/offered_contract.rs
+++ b/ddk-manager/src/contract/offered_contract.rs
@@ -90,6 +90,9 @@ impl OfferedContract {
     }
 
     /// Creates a new [`OfferedContract`] from the given parameters.
+    ///
+    /// The CET locktime is pinned to the closest oracle event maturity so that
+    /// CETs are spendable exactly when the first event matures, never before.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: ContractId,
@@ -99,7 +102,6 @@ impl OfferedContract {
         funding_inputs: &[FundingInput],
         counter_party: &PublicKey,
         refund_delay: u32,
-        cet_locktime: u32,
         keys_id: KeysId,
         chain_hash: [u8; 32],
     ) -> Self {
@@ -109,6 +111,8 @@ impl OfferedContract {
 
         let latest_maturity = crate::utils::get_latest_maturity_date(&oracle_announcements)
             .expect("to be able to retrieve latest maturity date");
+        let cet_locktime = crate::utils::get_closest_maturity_date(&oracle_announcements)
+            .expect("to be able to retrieve closest maturity date");
 
         let fund_output_serial_id = get_new_serial_id();
         let contract_info = contract

--- a/ddk-manager/src/contract_updater.rs
+++ b/ddk-manager/src/contract_updater.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     conversion_utils::get_tx_input_infos,
     error::Error,
-    Blockchain, ChannelId, ContractSigner, ContractSignerProvider, Time, Wallet,
+    Blockchain, ChannelId, ContractSigner, ContractSignerProvider, Wallet,
 };
 
 /// Creates an [`OfferedContract`] and [`OfferDlc`] message from the provided
@@ -38,7 +38,6 @@ use crate::{
 pub async fn offer_contract<
     W: Deref,
     B: Deref,
-    T: Deref,
     X: ContractSigner,
     SP: Deref,
     C: Signing,
@@ -52,14 +51,12 @@ pub async fn offer_contract<
     counter_party: &PublicKey,
     wallet: &W,
     blockchain: &B,
-    time: &T,
     signer_provider: &SP,
     logger: &L,
 ) -> Result<(OfferedContract, OfferDlc), Error>
 where
     W::Target: Wallet,
     B::Target: Blockchain,
-    T::Target: Time,
     SP::Target: ContractSignerProvider<Signer = X>,
     L::Target: Logger,
 {
@@ -104,7 +101,6 @@ where
         &funding_inputs_info,
         counter_party,
         refund_delay,
-        time.unix_time_now() as u32,
         keys_id,
         chain_hash,
     );
@@ -1169,7 +1165,8 @@ where
     let fund_output_value = accepted_contract.dlc_transactions.get_fund_output().value;
     let fund_outpoint = accepted_contract.dlc_transactions.get_fund_outpoint();
 
-    // Create the cooperative close transaction
+    // Create the cooperative close transaction, paying the close fee at the
+    // contract's fee rate out of the fund output.
     let close_tx = ddk_dlc::channel::create_collaborative_close_transaction(
         &offered_contract.offer_params,
         offer_payout,
@@ -1177,8 +1174,9 @@ where
         counter_payout,
         fund_outpoint,
         fund_output_value,
+        offered_contract.fee_rate_per_vb,
         &[], // TODO: Add additional inputs parameter to prevent free option problem
-    );
+    )?;
 
     log_debug!(
         logger,
@@ -1234,10 +1232,23 @@ where
     let fund_output_value = accepted_contract.dlc_transactions.get_fund_output().value;
     let fund_outpoint = accepted_contract.dlc_transactions.get_fund_outpoint();
 
+    if close_message.fee_rate_per_vb != offered_contract.fee_rate_per_vb {
+        return Err(Error::InvalidParameters(format!(
+            "Close message fee rate does not match the contract fee rate. message={} contract={}",
+            close_message.fee_rate_per_vb, offered_contract.fee_rate_per_vb
+        )));
+    }
+
     let total_collateral = offered_contract.total_collateral;
+    if close_message.accept_payout > total_collateral {
+        return Err(Error::InvalidParameters(
+            "Accept payout is greater than total collateral".to_string(),
+        ));
+    }
     let offer_payout = total_collateral - close_message.accept_payout;
 
-    // Recreate the close transaction to verify
+    // Recreate the close transaction to verify, using the contract's fee rate
+    // like the creating side does.
     let mut close_tx = ddk_dlc::channel::create_collaborative_close_transaction(
         &offered_contract.offer_params,
         offer_payout,
@@ -1245,8 +1256,9 @@ where
         close_message.accept_payout,
         fund_outpoint,
         fund_output_value,
+        offered_contract.fee_rate_per_vb,
         &[], // No additional inputs for contract cooperative close verification
-    );
+    )?;
 
     log_debug!(
         logger,

--- a/ddk-manager/src/error.rs
+++ b/ddk-manager/src/error.rs
@@ -27,6 +27,10 @@ pub enum Error {
     DlcError(ddk_dlc::Error),
     /// An error occurred in the Secp library.
     SecpError(secp256k1_zkp::Error),
+    /// A counterparty's cooperative close proposal was not approved by the
+    /// application. The proposal is not broadcast and the contract stays in
+    /// its current state.
+    CooperativeCloseRejected(String),
 }
 
 impl fmt::Display for Error {
@@ -43,6 +47,9 @@ impl fmt::Display for Error {
             Error::DlcError(ref e) => write!(f, "Dlc error {e}"),
             Error::OracleError(ref s) => write!(f, "Oracle error {s}"),
             Error::SecpError(_) => write!(f, "Secp error"),
+            Error::CooperativeCloseRejected(ref s) => {
+                write!(f, "Cooperative close rejected: {s}")
+            }
         }
     }
 }
@@ -98,6 +105,7 @@ impl std::error::Error for Error {
             Error::OracleError(_) => None,
             Error::DlcError(e) => Some(e),
             Error::SecpError(e) => Some(e),
+            Error::CooperativeCloseRejected(_) => None,
         }
     }
 }

--- a/ddk-manager/src/manager.rs
+++ b/ddk-manager/src/manager.rs
@@ -71,6 +71,10 @@ static AUTOMATIC_REFUND: Lazy<bool> = Lazy::new(|| match std::env::var("AUTOMATI
 
 /// The delay to set the refund value to.
 pub const REFUND_DELAY: u32 = 86400 * 7;
+/// Tolerance for local clock skew: an oracle event is only considered matured
+/// once it is this many seconds past its maturity epoch, so a fast local clock
+/// cannot trigger a premature CET broadcast.
+pub const MATURITY_SKEW_SECS: u64 = 3600;
 /// Timeout in seconds when waiting for a peer's reply, after which a DLC channel
 /// is forced closed.
 pub const PEER_TIMEOUT: u64 = 3600;
@@ -80,6 +84,31 @@ type ClosableContractInfo<'a> = Option<(
     &'a AdaptorInfo,
     Vec<(usize, OracleAttestation)>,
 )>;
+
+/// Application hook consulted before a counterparty's cooperative close
+/// proposal is broadcast.
+///
+/// A valid signature on a [`CloseDlc`] is not consent: the counterparty
+/// chooses `accept_payout` freely, up to the full collateral. The application
+/// must check the proposed payout against its own expectation (oracle state,
+/// market price, user confirmation, ...) and return `Ok(true)` only when the
+/// terms are acceptable. When no approver is set on the [`Manager`], every
+/// counterparty close proposal is rejected.
+pub trait CooperativeCloseApprover: Send + Sync {
+    /// Returns whether the close proposal paying `accept_payout` to the
+    /// counterparty of the contract with the given id should be broadcast.
+    fn approve_counterparty_close(
+        &self,
+        contract_id: ContractId,
+        accept_payout: Amount,
+    ) -> Result<bool, Error>;
+}
+
+impl std::fmt::Debug for dyn CooperativeCloseApprover {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("CooperativeCloseApprover")
+    }
+}
 
 /// Used to create and update DLCs.
 #[derive(Debug)]
@@ -113,6 +142,7 @@ pub struct Manager<
     time: T,
     fee_estimator: F,
     logger: L,
+    close_approver: Option<Arc<dyn CooperativeCloseApprover>>,
 }
 
 macro_rules! get_contract_in_state {
@@ -195,6 +225,10 @@ where
     L::Target: Logger,
 {
     /// Create a new Manager struct.
+    ///
+    /// `close_approver` is consulted before a counterparty's cooperative close
+    /// proposal is broadcast; with `None`, [`Manager::accept_cooperative_close`]
+    /// rejects every proposal.
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all)]
     pub async fn new(
@@ -206,6 +240,7 @@ where
         time: T,
         fee_estimator: F,
         logger: L,
+        close_approver: Option<Arc<dyn CooperativeCloseApprover>>,
     ) -> Result<Self, Error> {
         let init_height = blockchain.get_blockchain_height().await?;
         let chain_monitor = Mutex::new(
@@ -230,6 +265,7 @@ where
             fee_estimator,
             chain_monitor,
             logger,
+            close_approver,
         })
     }
 
@@ -390,7 +426,6 @@ where
             &counter_party,
             &self.wallet,
             &self.blockchain,
-            &self.time,
             &self.signer_provider,
             &self.logger,
         )
@@ -441,7 +476,6 @@ where
             &counter_party,
             &self.wallet,
             &self.blockchain,
-            &self.time,
             &self.signer_provider,
             &self.logger,
         )
@@ -999,7 +1033,8 @@ where
                 .oracle_announcements
                 .iter()
                 .filter(|x| {
-                    (x.oracle_event.event_maturity_epoch as u64) <= self.time.unix_time_now()
+                    (x.oracle_event.event_maturity_epoch as u64) + MATURITY_SKEW_SECS
+                        <= self.time.unix_time_now()
                 })
                 .enumerate()
                 .collect();
@@ -1686,6 +1721,15 @@ where
     /// Initiates a cooperative close of a contract by creating and signing a closing transaction.
     /// Returns a CloseDlc message to be sent to the counter party.
     /// The contract remains in Confirmed state until the close transaction is broadcast.
+    ///
+    /// # Warning
+    ///
+    /// The returned [`CloseDlc`] carries a signature over a transaction that
+    /// pays `counter_payout` to the counterparty out of the contract's funds.
+    /// Nothing binds `counter_payout` to any oracle outcome: the caller is
+    /// fully responsible for choosing a payout it is willing to give away. The
+    /// counterparty can broadcast the close transaction at any time once it
+    /// holds this message.
     #[tracing::instrument(skip_all, level = "debug")]
     pub async fn cooperative_close_contract(
         &self,
@@ -1741,6 +1785,15 @@ where
 
     /// Accepts a cooperative close request by completing the close transaction
     /// and broadcasting it to the network.
+    ///
+    /// # Warning
+    ///
+    /// A valid signature on the [`CloseDlc`] is not consent: the counterparty
+    /// chooses `accept_payout` freely, up to the full collateral. The
+    /// [`CooperativeCloseApprover`] set at [`Manager::new`] is consulted with
+    /// the proposed payout before anything is broadcast; without one, or when
+    /// it declines, this returns [`Error::CooperativeCloseRejected`] and the
+    /// contract stays in its current state.
     #[tracing::instrument(skip_all, level = "debug")]
     pub async fn accept_cooperative_close(
         &self,
@@ -1749,6 +1802,24 @@ where
     ) -> Result<(), Error> {
         let signed_contract =
             get_contract_in_state!(self, contract_id, Confirmed, None as Option<PublicKey>)?;
+
+        let approver = self.close_approver.as_ref().ok_or_else(|| {
+            Error::CooperativeCloseRejected(
+                "no cooperative close approver is configured".to_string(),
+            )
+        })?;
+        if !approver.approve_counterparty_close(*contract_id, close_message.accept_payout)? {
+            log_warn!(
+                self.logger,
+                "Cooperative close proposal declined by the application. contract_id={} accept_payout={}",
+                contract_id.to_lower_hex_string(),
+                close_message.accept_payout,
+            );
+            return Err(Error::CooperativeCloseRejected(format!(
+                "close proposal declined by the application. accept_payout={}",
+                close_message.accept_payout
+            )));
+        }
 
         let close_tx = crate::contract_updater::complete_cooperative_close(
             &self.secp,

--- a/ddk-manager/src/utils.rs
+++ b/ddk-manager/src/utils.rs
@@ -281,6 +281,19 @@ pub(crate) fn get_latest_maturity_date(
         })
 }
 
+pub(crate) fn get_closest_maturity_date(
+    announcements: &[Vec<OracleAnnouncement>],
+) -> Result<u32, Error> {
+    announcements
+        .iter()
+        .flatten()
+        .map(|x| x.oracle_event.event_maturity_epoch)
+        .min()
+        .ok_or_else(|| {
+            Error::InvalidParameters("Could not find minimum event maturity.".to_string())
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/ddk-manager/test_inputs/offer_contract.json
+++ b/ddk-manager/test_inputs/offer_contract.json
@@ -106,7 +106,7 @@
   "changeSerialId": 16919534260907952016,
   "fundOutputSerialId": 5054305248376932341,
   "feeRatePerVb": 2,
-  "cetLocktime": 1623133103,
+  "cetLocktime": 1623133104,
   "refundLocktime": 1623737904,
   "keysId": [
     16, 175, 248, 204, 229, 173, 124, 107, 34, 204, 75, 138, 154, 151, 193, 8,

--- a/ddk-manager/tests/manager_execution_tests.rs
+++ b/ddk-manager/tests/manager_execution_tests.rs
@@ -295,9 +295,26 @@ type TestManager = Manager<
 /// path in its own `async fn` also keeps the harness off the stack: a single
 /// function holding all of them needs a frame big enough for the largest
 /// branch of every one at once.
+/// Close approver shared by both managers: approves everything unless a test
+/// flips it to decline.
+struct TestCloseApprover {
+    approve: AtomicBool,
+}
+
+impl ddk_manager::manager::CooperativeCloseApprover for TestCloseApprover {
+    fn approve_counterparty_close(
+        &self,
+        _contract_id: ContractId,
+        _accept_payout: Amount,
+    ) -> Result<bool, ddk_manager::error::Error> {
+        Ok(self.approve.load(Ordering::SeqCst))
+    }
+}
+
 struct TestContext {
     bob: Arc<Mutex<TestManager>>,
     alice: Arc<Mutex<TestManager>>,
+    close_approver: Arc<TestCloseApprover>,
     bob_wallet: Arc<DlcDevKitWallet>,
     alice_wallet: Arc<DlcDevKitWallet>,
     electrs: Arc<EsploraClient>,
@@ -1325,6 +1342,10 @@ async fn manager_execution_test_inner(test_params: TestParams, path: TestPath, m
     refresh_wallet(&alice_wallet, TOTAL_COLLATERAL.to_sat()).await;
     refresh_wallet(&bob_wallet, TOTAL_COLLATERAL.to_sat()).await;
 
+    let close_approver = Arc::new(TestCloseApprover {
+        approve: AtomicBool::new(true),
+    });
+
     let alice_manager = Arc::new(Mutex::new(
         Manager::new(
             Arc::clone(&alice_wallet),
@@ -1335,6 +1356,7 @@ async fn manager_execution_test_inner(test_params: TestParams, path: TestPath, m
             Arc::clone(&mock_time),
             Arc::clone(&electrs),
             logger.clone(),
+            Some(close_approver.clone()),
         )
         .await
         .unwrap(),
@@ -1352,6 +1374,7 @@ async fn manager_execution_test_inner(test_params: TestParams, path: TestPath, m
             Arc::clone(&mock_time),
             Arc::clone(&electrs),
             logger.clone(),
+            Some(close_approver.clone()),
         )
         .await
         .unwrap(),
@@ -1415,6 +1438,7 @@ async fn manager_execution_test_inner(test_params: TestParams, path: TestPath, m
     let mut ctx = TestContext {
         bob: bob_manager,
         alice: alice_manager,
+        close_approver,
         bob_wallet: Arc::clone(&bob_wallet),
         alice_wallet: Arc::clone(&alice_wallet),
         electrs: Arc::clone(&electrs),
@@ -1572,6 +1596,12 @@ async fn close_path(
     manual_close: bool,
 ) {
     if !manual_close {
+        test_utils::set_time(
+            (EVENT_MATURITY as u64) + ddk_manager::manager::MATURITY_SKEW_SECS + 1,
+        );
+    } else {
+        // Past maturity so the CET locktime is satisfied, but within the skew
+        // window so the automatic path does not close the contract first.
         test_utils::set_time((EVENT_MATURITY as u64) + 1);
     }
 
@@ -1651,7 +1681,9 @@ async fn refund_path(
     manual_close: bool,
 ) {
     if !manual_close {
-        test_utils::set_time((EVENT_MATURITY as u64) + 1);
+        test_utils::set_time(
+            (EVENT_MATURITY as u64) + ddk_manager::manager::MATURITY_SKEW_SECS + 1,
+        );
     }
 
     let first = random_party();
@@ -1730,7 +1762,26 @@ async fn cooperative_close_path(ctx: &mut TestContext, contract_id: ContractId) 
         .await
         .expect("Error initiating cooperative close");
 
-    // Bob receives and accepts the cooperative close.
+    // With the application hook declining, a valid close message must not be
+    // broadcast and the contract must stay Confirmed.
+    ctx.close_approver.approve.store(false, Ordering::SeqCst);
+    let declined = ctx
+        .bob
+        .lock()
+        .await
+        .accept_cooperative_close(&contract_id, &close_msg)
+        .await;
+    assert!(
+        matches!(
+            declined,
+            Err(ddk_manager::error::Error::CooperativeCloseRejected(_))
+        ),
+        "Declined cooperative close should return CooperativeCloseRejected"
+    );
+    periodic_check!(ctx.bob, contract_id, Confirmed);
+
+    // With the hook approving, Bob accepts the cooperative close.
+    ctx.close_approver.approve.store(true, Ordering::SeqCst);
     ctx.bob
         .lock()
         .await
@@ -1744,8 +1795,9 @@ async fn cooperative_close_path(ctx: &mut TestContext, contract_id: ContractId) 
     // Alice does not know about the close yet.
     periodic_check!(ctx.alice, contract_id, Confirmed);
 
-    // Mine a few blocks to partially confirm the close transaction.
-    ctx.mine(3).await;
+    // Mine one block: the close transaction is confirmed, but stays below the
+    // NB_CONFIRMATIONS (3) threshold that moves a contract to Closed.
+    ctx.mine(1).await;
 
     // Alice now detects the pending close transaction.
     periodic_check!(ctx.alice, contract_id, PreClosed);
@@ -1766,6 +1818,44 @@ async fn cooperative_close_path(ctx: &mut TestContext, contract_id: ContractId) 
     assert!(
         closed_contract.attestations.is_none(),
         "Cooperative close should not have attestations"
+    );
+
+    // The mined close transaction pays a fee close to the contract fee rate:
+    // at least the target rate over its virtual size, and the whole CET fee
+    // reserve above the payouts at most.
+    let alice_contract = ctx.contract(Party::Alice, &contract_id).await;
+    let Contract::Closed(ref alice_closed) = alice_contract else {
+        panic!("Alice's contract should be in Closed state");
+    };
+    let signed_contract = &alice_closed.signed_contract;
+    let close_tx = alice_closed
+        .signed_cet
+        .as_ref()
+        .expect("Closed cooperative contract should hold the close transaction");
+    let fund_output_value = signed_contract
+        .accepted_contract
+        .dlc_transactions
+        .get_fund_output()
+        .value;
+    let outputs_value: Amount = close_tx.output.iter().map(|o| o.value).sum();
+    let fee = fund_output_value - outputs_value;
+    let fee_rate = signed_contract
+        .accepted_contract
+        .offered_contract
+        .fee_rate_per_vb;
+    let min_fee = Amount::from_sat(close_tx.vsize() as u64 * fee_rate);
+    assert!(
+        fee >= min_fee,
+        "Close transaction fee {fee} is below the contract fee rate ({min_fee} for {fee_rate} sat/vB)"
+    );
+    let reserve = fund_output_value
+        - signed_contract
+            .accepted_contract
+            .offered_contract
+            .total_collateral;
+    assert!(
+        fee <= reserve + Amount::from_sat(1),
+        "Close transaction fee {fee} exceeds the CET fee reserve {reserve}"
     );
 }
 
@@ -1979,7 +2069,7 @@ async fn splice_path(
     // Only the last contract in the chain is still open, so advancing past its
     // maturity settles it and nothing else.
     let last_maturity = EVENT_MATURITY + (rounds.len() as u32) * SPLICE_MATURITY_STEP;
-    test_utils::set_time(last_maturity as u64 + 1);
+    test_utils::set_time(last_maturity as u64 + ddk_manager::manager::MATURITY_SKEW_SECS + 1);
 
     // Every contract the chain replaced is closed, and a closed contract cannot
     // be spliced a second time.

--- a/ddk-manager/tests/manager_tests.rs
+++ b/ddk-manager/tests/manager_tests.rs
@@ -71,6 +71,7 @@ async fn get_manager(logger: Arc<Logger>) -> TestManager {
         time,
         blockchain,
         logger,
+        None,
     )
     .await
     .unwrap()

--- a/ddk/src/builder.rs
+++ b/ddk/src/builder.rs
@@ -2,7 +2,7 @@ use crate::logger::{log_error, log_info, WriteLog};
 use bip39::{Language, Mnemonic};
 use bitcoin::key::rand::Fill;
 use bitcoin::Network;
-use ddk_manager::manager::Manager;
+use ddk_manager::manager::{CooperativeCloseApprover, Manager};
 use ddk_manager::SystemTimeProvider;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -43,6 +43,7 @@ pub struct Builder<T, S, O> {
     network: Network,
     seed_bytes: [u8; 64],
     logger: Option<Arc<Logger>>,
+    close_approver: Option<Arc<dyn CooperativeCloseApprover>>,
 }
 
 /// Defaults when creating a DDK application
@@ -63,6 +64,7 @@ impl<T: Transport, S: Storage, O: Oracle> Default for Builder<T, S, O> {
             network: DEFAULT_NETWORK,
             seed_bytes: [0u8; 64],
             logger: None,
+            close_approver: None,
         }
     }
 }
@@ -156,6 +158,17 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
         self
     }
 
+    /// Set the hook consulted before a counterparty's cooperative close
+    /// proposal is broadcast. Without one, every counterparty close proposal
+    /// is rejected.
+    pub fn set_cooperative_close_approver(
+        &mut self,
+        close_approver: Arc<dyn CooperativeCloseApprover>,
+    ) -> &mut Self {
+        self.close_approver = Some(close_approver);
+        self
+    }
+
     /// Setup the logger based on the provided logger or use default console logging
     fn setup_logger(&self, name: &str) -> Result<Arc<Logger>, Error> {
         match &self.logger {
@@ -243,6 +256,7 @@ impl<T: Transport, S: Storage, O: Oracle> Builder<T, S, O> {
                 Arc::new(SystemTimeProvider {}),
                 wallet.clone(),
                 logger.clone(),
+                self.close_approver.clone(),
             )
             .await?,
         );

--- a/ddk/src/contract/tests.rs
+++ b/ddk/src/contract/tests.rs
@@ -118,7 +118,7 @@ fn messages_with_serial_ids(offer_ids: &[u64], accept_ids: &[u64]) -> (OfferDlc,
         change_serial_id: 2,
         fund_output_serial_id: 3,
         fee_rate_per_vb: 2,
-        cet_locktime: 500,
+        cet_locktime: 750,
         refund_locktime: 1_000,
     };
     let accept = AcceptDlc {

--- a/ddk/tests/stateless.rs
+++ b/ddk/tests/stateless.rs
@@ -257,7 +257,7 @@ fn offer_params(
         party: offerer.party_params(secp, funding_inputs),
         fund_output_serial_id: None,
         fee_rate_per_vb: 2,
-        cet_locktime: 500,
+        cet_locktime: 750,
         refund_locktime: 1_000,
         contract_flags: 0,
     }

--- a/dlc-messages/src/lib.rs
+++ b/dlc-messages/src/lib.rs
@@ -387,13 +387,16 @@ impl OfferDlc {
             }
         }
 
+        // The CET locktime is pinned to the closest maturity date: a lower value
+        // produces CETs spendable before the event matures, a higher value delays
+        // execution past it.
         let closest_maturity_date = self.contract_info.get_closest_maturity_date();
-        let valid_dates = self.cet_locktime <= closest_maturity_date
+        let valid_dates = self.cet_locktime == closest_maturity_date
             && closest_maturity_date + min_timeout_interval <= self.refund_locktime
             && self.refund_locktime <= closest_maturity_date + max_timeout_interval;
         if !valid_dates {
             return Err(Error::InvalidArgument(
-                "Locktime is less than closest maturity date".to_string(),
+                "CET locktime must equal the closest maturity date and the refund locktime must be within the timeout interval".to_string(),
             ));
         }
 
@@ -781,13 +784,25 @@ mod tests {
         let mut invalid_maturity = offer.clone();
         invalid_maturity.cet_locktime += 3;
 
+        let mut premature_cet_locktime = offer.clone();
+        premature_cet_locktime.cet_locktime -= 3;
+
+        let mut zero_cet_locktime = offer.clone();
+        zero_cet_locktime.cet_locktime = 0;
+
         let mut too_short_timeout = offer.clone();
         too_short_timeout.refund_locktime -= 100;
 
         let mut too_long_timeout = offer;
         too_long_timeout.refund_locktime -= 100;
 
-        for invalid in &[invalid_maturity, too_short_timeout, too_long_timeout] {
+        for invalid in &[
+            invalid_maturity,
+            premature_cet_locktime,
+            zero_cet_locktime,
+            too_short_timeout,
+            too_long_timeout,
+        ] {
             invalid
                 .validate(SECP256K1, 86400 * 7, 86400 * 14)
                 .expect_err("Should not pass validation of invalid offer message.");

--- a/dlc-messages/src/test_inputs/offer_msg_disjoint.json
+++ b/dlc-messages/src/test_inputs/offer_msg_disjoint.json
@@ -347,6 +347,6 @@
   "changeSerialId": 11651058207702948365,
   "fundOutputSerialId": 16318646099148843066,
   "feeRatePerVb": 2,
-  "cetLocktime": 1623133103,
+  "cetLocktime": 1623133104,
   "refundLocktime": 1623737904
 }

--- a/dlc/src/channel/mod.rs
+++ b/dlc/src/channel/mod.rs
@@ -561,20 +561,28 @@ pub fn create_and_sign_punish_settle_transaction<C: Signing>(
     Ok(tx)
 }
 
-/// Create a transaction for collaboratively closing a channel.
+/// Create a transaction for collaboratively closing a channel or a contract.
+///
+/// The transaction pays a fee at `fee_rate_per_vb` out of the fund output: the
+/// surplus of the fund output over the two payouts (the CET fee reserve for
+/// contracts, zero for channels) is returned to the parties evenly once the
+/// close fee is taken, each party covering half. Truncated satoshis and any
+/// share a party cannot cover are left to the fee.
 ///
 /// This function is primarily intended for on-chain DLC contracts where the offeror
 /// can provide additional inputs to prevent the free option problem. For off-chain
 /// channels, the additional_inputs parameter should typically be empty.
+#[allow(clippy::too_many_arguments)]
 pub fn create_collaborative_close_transaction(
     offer_params: &PartyParams,
     offer_payout: Amount,
     accept_params: &PartyParams,
     accept_payout: Amount,
     fund_outpoint: OutPoint,
-    _fund_output_amount: Amount,
+    fund_output_amount: Amount,
+    fee_rate_per_vb: u64,
     additional_inputs: &[OutPoint],
-) -> Transaction {
+) -> Result<Transaction, Error> {
     let mut inputs = vec![TxIn {
         previous_output: fund_outpoint,
         witness: Witness::default(),
@@ -588,14 +596,46 @@ pub fn create_collaborative_close_transaction(
         sequence: crate::util::DISABLE_LOCKTIME,
     }));
 
-    //TODO(tibo): add fee re-payment
+    // The close transaction has the structure of a CET (fund input plus the
+    // two payout outputs); additional fee-paying inputs are counted with a
+    // P2WPKH witness.
+    let output_spk_weight = (offer_params.payout_script_pubkey.len()
+        + accept_params.payout_script_pubkey.len())
+    .checked_mul(4)
+    .ok_or_else(|| Error::InvalidArgument("Output spk weight overflow".to_string()))?;
+    let additional_input_weight = additional_inputs
+        .len()
+        .checked_mul(crate::TX_INPUT_BASE_WEIGHT + crate::P2WPKH_WITNESS_SIZE)
+        .ok_or_else(|| Error::InvalidArgument("Additional input weight overflow".to_string()))?;
+    let total_weight = crate::CET_BASE_WEIGHT + output_spk_weight + additional_input_weight;
+    let fee = crate::util::weight_to_fee(total_weight, fee_rate_per_vb)?;
+
+    let total_payout = offer_payout
+        .checked_add(accept_payout)
+        .ok_or_else(|| Error::InvalidArgument("Payout overflow".to_string()))?;
+    if fund_output_amount < total_payout {
+        return Err(Error::InvalidArgument(
+            "Payouts are greater than the fund output value".to_string(),
+        ));
+    }
+    if fund_output_amount <= fee {
+        return Err(Error::InvalidArgument(
+            "Fund output value cannot cover the close transaction fee".to_string(),
+        ));
+    }
+    let surplus = fund_output_amount - total_payout;
+
+    let half_net = (surplus.to_sat() as i64 - fee.to_sat() as i64) / 2;
+    let offer_value = (offer_payout.to_sat() as i64 + half_net).max(0) as u64;
+    let accept_value = (accept_payout.to_sat() as i64 + half_net).max(0) as u64;
+
     let offer_output = TxOut {
-        value: offer_payout,
+        value: Amount::from_sat(offer_value),
         script_pubkey: offer_params.payout_script_pubkey.clone(),
     };
 
     let accept_output = TxOut {
-        value: accept_payout,
+        value: Amount::from_sat(accept_value),
         script_pubkey: accept_params.payout_script_pubkey.clone(),
     };
 
@@ -607,12 +647,12 @@ pub fn create_collaborative_close_transaction(
 
     output = crate::util::discard_dust(output, crate::DUST_LIMIT);
 
-    Transaction {
+    Ok(Transaction {
         version: crate::TX_VERSION,
         lock_time: LockTime::ZERO,
         input: inputs,
         output,
-    }
+    })
 }
 
 /// Returns a descriptor for a buffer transaction.


### PR DESCRIPTION
## Summary
Fixes the remaining high-severity red-team findings H3 and H4: cooperative close transactions now pay an explicit weight-based fee and require application approval before a counterparty's close proposal is broadcast, and CET locktimes are pinned to the closest oracle maturity with a clock-skew guard on the automatic close path.

## Changes
- `create_collaborative_close_transaction` takes a fee rate and returns `Result`: it pays a weight-based fee out of the fund output and returns the surplus (the CET fee reserve) to the parties evenly, instead of donating the whole reserve to miners. Both contract and channel callers pass their stored fee rate; the two close-fee TODOs are resolved.
- `complete_cooperative_close` rejects a `CloseDlc` whose fee rate differs from the contract's, and rejects `accept_payout > total_collateral` (previously an `Amount` subtraction panic).
- New `CooperativeCloseApprover` trait, set at `Manager::new`. `accept_cooperative_close` consults it before broadcasting; without one, or on decline, it returns the new typed `Error::CooperativeCloseRejected` and the contract stays in its state. `ddk` exposes `Builder::set_cooperative_close_approver`. The consent footgun is documented on both close methods.
- `OfferDlc::validate` pins `cet_locktime` to the closest maturity date, so an offer with `cet_locktime = 0` (an immediately spendable CET) is rejected. Outbound offers derive `cet_locktime` from the announcements in `OfferedContract::new` instead of the wall clock.
- New `MATURITY_SKEW_SECS` (3600 s): the automatic close path only treats an oracle event as matured one hour past its maturity epoch, so a fast local clock cannot broadcast a premature CET. Manual close still works inside the skew window.
- Test fix for a pre-existing failure: the cooperative close execution tests mined exactly `NB_CONFIRMATIONS` blocks for their partial-confirmation assertion, so the observer jumped straight to `Closed`. They now mine one block, and additionally cover hook decline/approval and assert the mined close fee is at least the contract rate over vsize and at most the CET reserve.

## Testing
- Regtest execution tests: all three cooperative close tests, enum auto/manual close, refund and manual refund, numerical auto/manual, splice chain manual, splice-in manual and auto.
- Unit suites: `ddk-manager` (49), `ddk` (42), `ddk-messages` (45), stateless (31). `cargo fmt` and `clippy --workspace --all-targets` are clean.
